### PR TITLE
Return discovered alphabets while tokenizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* Add API to retrieve discovered alphabet during tokenization
 * Flag to convert joiners to spacers
 
 ### Fixes and improvements

--- a/include/onmt/ITokenizer.h
+++ b/include/onmt/ITokenizer.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 #include <string>
+#include <set>
 
 namespace onmt
 {
@@ -16,6 +17,10 @@ namespace onmt
     virtual void tokenize(const std::string& text,
                           std::vector<std::string>& words,
                           std::vector<std::vector<std::string> >& features) const = 0;
+    virtual void tokenize(const std::string& text,
+                          std::vector<std::string>& words,
+                          std::vector<std::vector<std::string> >& features,
+                          std::set<std::string>& alphabets) const = 0;
     virtual void tokenize(const std::string& text, std::vector<std::string>& words) const;
 
     virtual std::string detokenize(const std::vector<std::string>& words,

--- a/include/onmt/ITokenizer.h
+++ b/include/onmt/ITokenizer.h
@@ -2,7 +2,7 @@
 
 #include <vector>
 #include <string>
-#include <set>
+#include <unordered_map>
 
 namespace onmt
 {
@@ -20,7 +20,7 @@ namespace onmt
     virtual void tokenize(const std::string& text,
                           std::vector<std::string>& words,
                           std::vector<std::vector<std::string> >& features,
-                          std::set<std::string>& alphabets) const = 0;
+                          std::unordered_map<std::string,size_t>& alphabets) const = 0;
     virtual void tokenize(const std::string& text, std::vector<std::string>& words) const;
 
     virtual std::string detokenize(const std::vector<std::string>& words,

--- a/include/onmt/ITokenizer.h
+++ b/include/onmt/ITokenizer.h
@@ -20,7 +20,7 @@ namespace onmt
     virtual void tokenize(const std::string& text,
                           std::vector<std::string>& words,
                           std::vector<std::vector<std::string> >& features,
-                          std::unordered_map<std::string,size_t>& alphabets) const = 0;
+                          std::unordered_map<std::string, size_t>& alphabets) const = 0;
     virtual void tokenize(const std::string& text, std::vector<std::string>& words) const;
 
     virtual std::string detokenize(const std::vector<std::string>& words,

--- a/include/onmt/SpaceTokenizer.h
+++ b/include/onmt/SpaceTokenizer.h
@@ -18,7 +18,7 @@ namespace onmt
     void tokenize(const std::string& text,
                   std::vector<std::string>& words,
                   std::vector<std::vector<std::string> >& features,
-                  std::unordered_map<std::string,size_t>& alphabets) const override;
+                  std::unordered_map<std::string, size_t>& alphabets) const override;
 
     std::string detokenize(const std::vector<std::string>& words,
                            const std::vector<std::vector<std::string> >& features) const override;

--- a/include/onmt/SpaceTokenizer.h
+++ b/include/onmt/SpaceTokenizer.h
@@ -18,7 +18,7 @@ namespace onmt
     void tokenize(const std::string& text,
                   std::vector<std::string>& words,
                   std::vector<std::vector<std::string> >& features,
-                  std::set<std::string>& alphabets) const override;
+                  std::unordered_map<std::string,size_t>& alphabets) const override;
 
     std::string detokenize(const std::vector<std::string>& words,
                            const std::vector<std::vector<std::string> >& features) const override;

--- a/include/onmt/SpaceTokenizer.h
+++ b/include/onmt/SpaceTokenizer.h
@@ -15,6 +15,10 @@ namespace onmt
     void tokenize(const std::string& text,
                   std::vector<std::string>& words,
                   std::vector<std::vector<std::string> >& features) const override;
+    void tokenize(const std::string& text,
+                  std::vector<std::string>& words,
+                  std::vector<std::vector<std::string> >& features,
+                  std::set<std::string>& alphabets) const override;
 
     std::string detokenize(const std::vector<std::string>& words,
                            const std::vector<std::vector<std::string> >& features) const override;

--- a/include/onmt/Tokenizer.h
+++ b/include/onmt/Tokenizer.h
@@ -52,6 +52,11 @@ namespace onmt
                   std::vector<std::string>& words,
                   std::vector<std::vector<std::string> >& features) const override;
 
+    void tokenize(const std::string& text,
+                  std::vector<std::string>& words,
+                  std::vector<std::vector<std::string> >& features,
+                  std::set<std::string> &alphabets) const override;
+
     std::string detokenize(const std::vector<std::string>& words,
                            const std::vector<std::vector<std::string> >& features) const override;
 

--- a/include/onmt/Tokenizer.h
+++ b/include/onmt/Tokenizer.h
@@ -55,7 +55,7 @@ namespace onmt
     void tokenize(const std::string& text,
                   std::vector<std::string>& words,
                   std::vector<std::vector<std::string> >& features,
-                  std::set<std::string> &alphabets) const override;
+                  std::unordered_map<std::string,size_t> &alphabets) const override;
 
     std::string detokenize(const std::vector<std::string>& words,
                            const std::vector<std::vector<std::string> >& features) const override;

--- a/include/onmt/Tokenizer.h
+++ b/include/onmt/Tokenizer.h
@@ -55,7 +55,7 @@ namespace onmt
     void tokenize(const std::string& text,
                   std::vector<std::string>& words,
                   std::vector<std::vector<std::string> >& features,
-                  std::unordered_map<std::string,size_t> &alphabets) const override;
+                  std::unordered_map<std::string, size_t>& alphabets) const override;
 
     std::string detokenize(const std::vector<std::string>& words,
                            const std::vector<std::vector<std::string> >& features) const override;

--- a/src/SpaceTokenizer.cc
+++ b/src/SpaceTokenizer.cc
@@ -16,7 +16,7 @@ namespace onmt
   void SpaceTokenizer::tokenize(const std::string& text,
                                 std::vector<std::string>& words,
                                 std::vector<std::vector<std::string> >& features,
-                                std::set<std::string>&) const {
+                                std::unordered_map<std::string,size_t>&) const {
     return tokenize(text, words, features);
   }
 

--- a/src/SpaceTokenizer.cc
+++ b/src/SpaceTokenizer.cc
@@ -16,7 +16,7 @@ namespace onmt
   void SpaceTokenizer::tokenize(const std::string& text,
                                 std::vector<std::string>& words,
                                 std::vector<std::vector<std::string> >& features,
-                                std::unordered_map<std::string,size_t>&) const {
+                                std::unordered_map<std::string, size_t>&) const {
     return tokenize(text, words, features);
   }
 

--- a/src/SpaceTokenizer.cc
+++ b/src/SpaceTokenizer.cc
@@ -15,6 +15,13 @@ namespace onmt
 
   void SpaceTokenizer::tokenize(const std::string& text,
                                 std::vector<std::string>& words,
+                                std::vector<std::vector<std::string> >& features,
+                                std::set<std::string>&) const {
+    return tokenize(text, words, features);
+  }
+
+  void SpaceTokenizer::tokenize(const std::string& text,
+                                std::vector<std::string>& words,
                                 std::vector<std::vector<std::string> >& features) const
   {
     std::vector<std::string> chunks = unicode::split_utf8(text, " ");

--- a/src/Tokenizer.cc
+++ b/src/Tokenizer.cc
@@ -121,7 +121,15 @@ namespace onmt
 
   void Tokenizer::tokenize(const std::string& text,
                            std::vector<std::string>& words,
-                           std::vector<std::vector<std::string> >& features) const
+                           std::vector<std::vector<std::string> >& features) const {
+    std::set<std::string> alphabets;
+    return tokenize(text, words, features, alphabets);
+  }
+
+  void Tokenizer::tokenize(const std::string& text,
+                           std::vector<std::string>& words,
+                           std::vector<std::vector<std::string> >& features,
+                           std::set<std::string> &alphabets) const
   {
     if (_mode == Mode::Space) {
       if (text.empty())
@@ -264,7 +272,10 @@ namespace onmt
 
             std::string alphabet;
             if (cur_letter && (_segment_alphabet_change || !_segment_alphabet.empty()))
-              alphabet = get_alphabet(v);
+              {
+                alphabet = get_alphabet(v);
+                alphabets.insert(alphabet);
+              }
 
             if (unicode::is_mark(v)) {
               // if we have a mark, we keep type of previous character

--- a/src/Tokenizer.cc
+++ b/src/Tokenizer.cc
@@ -272,18 +272,9 @@ namespace onmt
 
             std::string alphabet = get_alphabet(v);
             if (!alphabet.empty() && cur_letter)
-            {
-              if (alphabets.find(alphabet) != alphabets.end()) alphabets.at(alphabet)++;
-              else alphabets.insert(std::make_pair(alphabet,1));
-            }
-            else if (cur_number) {
-              if (alphabets.find("Numeric") != alphabets.end()) alphabets.at("Numeric")++;
-              else alphabets.insert(std::make_pair("Numeric",1));
-	    }
-	    else {
-              if (alphabets.find("Other") != alphabets.end()) alphabets.at("Other")++;
-              else alphabets.insert(std::make_pair("Other",1));
-            }
+              alphabets[alphabet]++;
+            else
+              alphabets[cur_number ? "Numeric" : "Other"]++;
 
             if (unicode::is_mark(v)) {
               // if we have a mark, we keep type of previous character

--- a/src/Tokenizer.cc
+++ b/src/Tokenizer.cc
@@ -122,14 +122,14 @@ namespace onmt
   void Tokenizer::tokenize(const std::string& text,
                            std::vector<std::string>& words,
                            std::vector<std::vector<std::string> >& features) const {
-    std::unordered_map<std::string,size_t> alphabets;
+    std::unordered_map<std::string, size_t> alphabets;
     return tokenize(text, words, features, alphabets);
   }
 
   void Tokenizer::tokenize(const std::string& text,
                            std::vector<std::string>& words,
                            std::vector<std::vector<std::string> >& features,
-                           std::unordered_map<std::string,size_t> &alphabets) const
+                           std::unordered_map<std::string, size_t>& alphabets) const
   {
     if (_mode == Mode::Space) {
       if (text.empty())

--- a/test/test.cc
+++ b/test/test.cc
@@ -28,7 +28,7 @@ static void test_tok(std::unique_ptr<ITokenizer>& tokenizer,
 static void test_tok_alphabet(std::unique_ptr<ITokenizer>& tokenizer,
                      const std::string& in,
                      const std::string& expected,
-                     const std::set<std::string>& expected_alphabets) {
+                     const std::unordered_map<std::string, size_t>& expected_alphabets) {
   std::vector<std::string> words;
   std::vector<std::vector<std::string> > features;
   std::unordered_map<std::string, size_t> alphabets;
@@ -46,7 +46,8 @@ static void test_tok_alphabet(std::unique_ptr<ITokenizer>& tokenizer,
   EXPECT_EQ(expected, output);
 
   for(auto it: expected_alphabets)
-    EXPECT_TRUE(alphabets.find(it) != alphabets.end());
+    EXPECT_TRUE(alphabets.find(it.first) != alphabets.end() &&
+                alphabets[it.first] == it.second);
 }
 
 static void test_tok_and_detok(std::unique_ptr<ITokenizer>& tokenizer,
@@ -289,10 +290,14 @@ TEST(TokenizerTest, SpacerAnnotate) {
 TEST(TokenizerTest, Alphabets) {
   auto tokenizer = std::unique_ptr<ITokenizer>(
     new Tokenizer(Tokenizer::Mode::Aggressive, Tokenizer::Flags::SegmentAlphabetChange));
-  std::set<std::string> lat_cyrillic_alphabets;
-  lat_cyrillic_alphabets.insert("Latin");
-  lat_cyrillic_alphabets.insert("Cyrillic");
+  std::unordered_map<std::string, size_t> lat_cyrillic_alphabets;
+  lat_cyrillic_alphabets["Latin"] = 3;
+  lat_cyrillic_alphabets["Cyrillic"] = 1;
   test_tok_alphabet(tokenizer, "rawБ", "raw Б", lat_cyrillic_alphabets);
+
+  std::unordered_map<std::string, size_t> han2;
+  han2["Han"] = 2;
+  test_tok_alphabet(tokenizer, "有 入", "有 入", han2);
 }
 
 int main(int argc, char *argv[]) {

--- a/test/test.cc
+++ b/test/test.cc
@@ -26,9 +26,9 @@ static void test_tok(std::unique_ptr<ITokenizer>& tokenizer,
 }
 
 static void test_tok_alphabet(std::unique_ptr<ITokenizer>& tokenizer,
-                     const std::string& in,
-                     const std::string& expected,
-                     const std::unordered_map<std::string, size_t>& expected_alphabets) {
+                              const std::string& in,
+                              const std::string& expected,
+                              const std::unordered_map<std::string, size_t>& expected_alphabets) {
   std::vector<std::string> words;
   std::vector<std::vector<std::string> > features;
   std::unordered_map<std::string, size_t> alphabets;

--- a/test/test.cc
+++ b/test/test.cc
@@ -31,7 +31,7 @@ static void test_tok_alphabet(std::unique_ptr<ITokenizer>& tokenizer,
                      const std::set<std::string>& expected_alphabets) {
   std::vector<std::string> words;
   std::vector<std::vector<std::string> > features;
-  std::set<std::string> alphabets;
+  std::unordered_map<std::string, size_t> alphabets;
 
   tokenizer->tokenize(in, words ,features, alphabets);
 
@@ -47,8 +47,6 @@ static void test_tok_alphabet(std::unique_ptr<ITokenizer>& tokenizer,
 
   for(auto it: expected_alphabets)
     EXPECT_TRUE(alphabets.find(it) != alphabets.end());
-  for(auto it: alphabets)
-    EXPECT_TRUE(expected_alphabets.find(it) != alphabets.end());
 }
 
 static void test_tok_and_detok(std::unique_ptr<ITokenizer>& tokenizer,

--- a/test/test.cc
+++ b/test/test.cc
@@ -25,6 +25,32 @@ static void test_tok(std::unique_ptr<ITokenizer>& tokenizer,
   }
 }
 
+static void test_tok_alphabet(std::unique_ptr<ITokenizer>& tokenizer,
+                     const std::string& in,
+                     const std::string& expected,
+                     const std::set<std::string>& expected_alphabets) {
+  std::vector<std::string> words;
+  std::vector<std::vector<std::string> > features;
+  std::set<std::string> alphabets;
+
+  tokenizer->tokenize(in, words ,features, alphabets);
+
+  std::string output;
+  for (size_t i = 0; i < words.size(); ++i)
+  {
+    if (i > 0)
+      output += " ";
+    output += words[i];
+  }
+
+  EXPECT_EQ(expected, output);
+
+  for(auto it: expected_alphabets)
+    EXPECT_TRUE(alphabets.find(it) != alphabets.end());
+  for(auto it: alphabets)
+    EXPECT_TRUE(expected_alphabets.find(it) != alphabets.end());
+}
+
 static void test_tok_and_detok(std::unique_ptr<ITokenizer>& tokenizer,
                                const std::string& in,
                                const std::string& expected) {
@@ -260,6 +286,15 @@ TEST(TokenizerTest, SpacerAnnotate) {
                      "Isn't it so-greatly working?",
                      "Isn ' t ▁it ▁so - greatly ▁working ?");
   test_tok_and_detok(tokenizer, "MP3", "MP 3");
+}
+
+TEST(TokenizerTest, Alphabets) {
+  auto tokenizer = std::unique_ptr<ITokenizer>(
+    new Tokenizer(Tokenizer::Mode::Aggressive, Tokenizer::Flags::SegmentAlphabetChange));
+  std::set<std::string> lat_cyrillic_alphabets;
+  lat_cyrillic_alphabets.insert("Latin");
+  lat_cyrillic_alphabets.insert("Cyrillic");
+  test_tok_alphabet(tokenizer, "rawБ", "raw Б", lat_cyrillic_alphabets);
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
keep count of the type of each character discovered during tokenization - will not work for space tokenization not parsing the actual string.