### PR TITLE
Add option to inject case information as new tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### New features
 
+* `CaseMarkup` flag to inject case information as new tokens
+
 ### Fixes and improvements
 
 * Do not break compilation for users with old SentencePiece versions

--- a/bindings/python/Python.cc
+++ b/bindings/python/Python.cc
@@ -1,4 +1,4 @@
-#define BOOST_PYTHON_MAX_ARITY 23
+#define BOOST_PYTHON_MAX_ARITY 24
 #include <boost/python.hpp>
 #include <boost/python/stl_iterator.hpp>
 
@@ -45,6 +45,7 @@ public:
                    bool spacer_annotate,
                    bool spacer_new,
                    bool case_feature,
+                   bool case_markup,
                    bool no_substitution,
                    bool preserve_placeholders,
                    bool preserve_segmented_tokens,
@@ -66,6 +67,8 @@ public:
       flags |= onmt::Tokenizer::Flags::SpacerNew;
     if (case_feature)
       flags |= onmt::Tokenizer::Flags::CaseFeature;
+    if (case_markup)
+      flags |= onmt::Tokenizer::Flags::CaseMarkup;
     if (no_substitution)
       flags |= onmt::Tokenizer::Flags::NoSubstitution;
     if (preserve_placeholders)
@@ -155,7 +158,7 @@ BOOST_PYTHON_MODULE(tokenizer)
 {
   py::class_<TokenizerWrapper>(
       "Tokenizer",
-      py::init<std::string, std::string, std::string, int, std::string, int, std::string, int, float, std::string, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, py::list>(
+      py::init<std::string, std::string, std::string, int, std::string, int, std::string, int, float, std::string, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, py::list>(
         (py::arg("bpe_model_path")="",
          py::arg("bpe_vocab_path")="",  // Keep for backward compatibility.
          py::arg("bpe_vocab_threshold")=50,  // Keep for backward compatibility.
@@ -170,6 +173,7 @@ BOOST_PYTHON_MODULE(tokenizer)
          py::arg("spacer_annotate")=false,
          py::arg("spacer_new")=false,
          py::arg("case_feature")=false,
+         py::arg("case_markup")=false,
          py::arg("no_substitution")=false,
          py::arg("preserve_placeholders")=false,
          py::arg("preserve_segmented_tokens")=false,

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -27,6 +27,7 @@ tokenizer = pyonmt.Tokenizer(
     spacer_annotate=False,
     spacer_new=False,
     case_feature=False,
+    case_markup=False,
     no_substitution=False,
     preserve_placeholders=False,
     preserve_segmented_tokens=False,

--- a/cli/tokenize.cc
+++ b/cli/tokenize.cc
@@ -23,6 +23,7 @@ int main(int argc, char* argv[])
     ("preserve_placeholders", po::bool_switch()->default_value(false), "do not mark placeholders with joiners or spacers")
     ("preserve_segmented_tokens", po::bool_switch()->default_value(false), "do not mark segmented tokens (segment_* options) with joiners or spacers")
     ("case_feature,c", po::bool_switch()->default_value(false), "lowercase corpus and generate case feature")
+    ("case_markup", po::bool_switch()->default_value(false), "lowercase corpus and inject case markup tokens")
     ("segment_case", po::bool_switch()->default_value(false), "Segment case feature, splits AbC to Ab C to be able to restore case")
     ("segment_numbers", po::bool_switch()->default_value(false), "Segment numbers into single digits")
     ("segment_alphabet", po::value<std::string>()->default_value(""), "comma-separated list of alphabets on which to segment all letters.")
@@ -52,6 +53,8 @@ int main(int argc, char* argv[])
   int flags = 0;
   if (vm["case_feature"].as<bool>())
     flags |= onmt::Tokenizer::Flags::CaseFeature;
+  if (vm["case_markup"].as<bool>())
+    flags |= onmt::Tokenizer::Flags::CaseMarkup;
   if (vm["joiner_annotate"].as<bool>())
     flags |= onmt::Tokenizer::Flags::JoinerAnnotate;
   if (vm["joiner_new"].as<bool>())

--- a/docs/options.md
+++ b/docs/options.md
@@ -68,6 +68,21 @@ Possible case types:
 * `M`: mixed
 * `N`: none
 
+### `case_markup` (boolean, default: `false`)
+
+Lowercase text input and inject case markups as additional tokens. This option also enables `segment_case`.
+
+```bash
+$ echo "Hello world!" | cli/tokenize --case_markup
+｟mrk_case_modifier_C｠ hello world !
+$ echo "Hello WORLD!" | cli/tokenize --case_markup
+｟mrk_case_modifier_C｠ hello ｟mrk_begin_case_region_U｠ world ｟mrk_end_case_region_U｠ !
+$ echo "Hello WOrld!" | cli/tokenize --case_markup
+｟mrk_case_modifier_C｠ hello ｟mrk_begin_case_region_U｠ wo ｟mrk_end_case_region_U｠ rld !
+$ echo "Hello WORLD!" | cli/tokenize --case_markup --bpe_model model.bpe
+｟mrk_case_modifier_C｠ he llo ｟mrk_begin_case_region_U｠ wo rld ｟mrk_end_case_region_U｠ !
+```
+
 ### `no_substitution` (boolean, default: `false`)
 
 Disable substitution of special characters defined by the Tokenizer and found in the input text (e.g. joiners, spacers, etc.).

--- a/include/onmt/AnnotatedToken.h
+++ b/include/onmt/AnnotatedToken.h
@@ -2,6 +2,8 @@
 
 #include <string>
 
+#include "onmt/CaseModifier.h"
+
 namespace onmt
 {
 
@@ -29,8 +31,22 @@ namespace onmt
     bool is_spacer() const;
     bool should_preserve() const;
 
+    bool begin_case_region() const;
+    bool end_case_region() const;
+    bool has_case() const;
+
+    void set_case(CaseModifier::Type type);
+    void set_case_region_begin(CaseModifier::Type type);
+    void set_case_region_end(CaseModifier::Type type);
+    CaseModifier::Type get_case() const;
+    CaseModifier::Type get_case_region_begin() const;
+    CaseModifier::Type get_case_region_end() const;
+
   private:
     std::string _str;
+    CaseModifier::Type _case = CaseModifier::Type::None;
+    CaseModifier::Type _begin_case_region = CaseModifier::Type::None;
+    CaseModifier::Type _end_case_region = CaseModifier::Type::None;
     bool _join_left = false;
     bool _join_right = false;
     bool _spacer = false;

--- a/include/onmt/CaseModifier.h
+++ b/include/onmt/CaseModifier.h
@@ -18,11 +18,27 @@ namespace onmt
       None
     };
 
+    static std::pair<std::string, Type> extract_case_type(const std::string& token);
     static std::pair<std::string, char> extract_case(const std::string& token);
     static std::string apply_case(const std::string& token, char feat);
+    static std::string apply_case(const std::string& token, Type type);
 
     static char type_to_char(Type type);
     static Type char_to_type(char feature);
+
+    enum class Markup
+    {
+      Modifier,
+      RegionBegin,
+      RegionEnd,
+      None
+    };
+
+    static Markup get_case_markup(const std::string& str);
+    static Type get_case_modifier_from_markup(const std::string& markup);
+    static std::string generate_case_markup(Type type);
+    static std::string generate_case_markup_begin(Type type);
+    static std::string generate_case_markup_end(Type type);
   };
 
 }

--- a/include/onmt/SubwordEncoder.h
+++ b/include/onmt/SubwordEncoder.h
@@ -19,6 +19,9 @@ namespace onmt
 
     virtual std::vector<std::string> encode(const std::string& str) const = 0;
     virtual std::vector<AnnotatedToken> encode_and_annotate(const AnnotatedToken& token) const;
+
+    static void propagate_token_properties(const AnnotatedToken& token,
+                                           std::vector<AnnotatedToken>& tokens);
   };
 
 }

--- a/include/onmt/Tokenizer.h
+++ b/include/onmt/Tokenizer.h
@@ -39,7 +39,8 @@ namespace onmt
       SentencePieceModel = 1 << 11,
       PreservePlaceholders = 1 << 12,
       SpacerNew = 1 << 13,
-      PreserveSegmentedTokens = 1 << 14
+      PreserveSegmentedTokens = 1 << 14,
+      CaseMarkup = 1 << 15,
     };
 
     static const std::string joiner_marker;
@@ -108,6 +109,7 @@ namespace onmt
     Mode _mode;
 
     bool _case_feature;
+    bool _case_markup;
     bool _joiner_annotate;
     bool _joiner_new;
     bool _with_separators;

--- a/src/AnnotatedToken.cc
+++ b/src/AnnotatedToken.cc
@@ -86,4 +86,49 @@ namespace onmt
     return _preserved;
   }
 
+  bool AnnotatedToken::begin_case_region() const
+  {
+    return _begin_case_region != CaseModifier::Type::None;
+  }
+
+  bool AnnotatedToken::end_case_region() const
+  {
+    return _end_case_region != CaseModifier::Type::None;
+  }
+
+  bool AnnotatedToken::has_case() const
+  {
+    return _case != CaseModifier::Type::None;
+  }
+
+  void AnnotatedToken::set_case(CaseModifier::Type type)
+  {
+    _case = type;
+  }
+
+  void AnnotatedToken::set_case_region_begin(CaseModifier::Type type)
+  {
+    _begin_case_region = type;
+  }
+
+  void AnnotatedToken::set_case_region_end(CaseModifier::Type type)
+  {
+    _end_case_region = type;
+  }
+
+  CaseModifier::Type AnnotatedToken::get_case() const
+  {
+    return _case;
+  }
+
+  CaseModifier::Type AnnotatedToken::get_case_region_begin() const
+  {
+    return _begin_case_region;
+  }
+
+  CaseModifier::Type AnnotatedToken::get_case_region_end() const
+  {
+    return _end_case_region;
+  }
+
 }

--- a/src/CaseModifier.cc
+++ b/src/CaseModifier.cc
@@ -1,9 +1,14 @@
 #include "onmt/CaseModifier.h"
 
+#include "onmt/Tokenizer.h"
 #include "onmt/unicode/Unicode.h"
 
 namespace onmt
 {
+
+  static std::string case_markup_prefix = "mrk_case_modifier_";
+  static std::string case_markup_begin_prefix = "mrk_begin_case_region_";
+  static std::string case_markup_end_prefix = "mrk_end_case_region_";
 
   static CaseModifier::Type update_type(CaseModifier::Type current, unicode::_type_letter type)
   {
@@ -43,6 +48,13 @@ namespace onmt
 
   std::pair<std::string, char> CaseModifier::extract_case(const std::string& token)
   {
+    auto pair = extract_case_type(token);
+    return std::make_pair(std::move(pair.first), type_to_char(pair.second));
+  }
+
+  std::pair<std::string, CaseModifier::Type>
+  CaseModifier::extract_case_type(const std::string& token)
+  {
     std::vector<std::string> chars;
     std::vector<unicode::code_point_t> code_points;
 
@@ -50,6 +62,7 @@ namespace onmt
 
     Type current_case = Type::None;
     std::string new_token;
+    new_token.reserve(chars.size());
 
     for (size_t i = 0; i < chars.size(); ++i)
     {
@@ -67,13 +80,16 @@ namespace onmt
       new_token += unicode::cp_to_utf8(v);
     }
 
-    return std::make_pair(new_token, type_to_char(current_case));
+    return std::make_pair(new_token, current_case);
   }
 
   std::string CaseModifier::apply_case(const std::string& token, char feat)
   {
-    Type case_type = char_to_type(feat);
+    return apply_case(token, char_to_type(feat));
+  }
 
+  std::string CaseModifier::apply_case(const std::string& token, Type case_type)
+  {
     if (case_type == Type::Lowercase || case_type == Type::None)
       return token;
 
@@ -83,6 +99,7 @@ namespace onmt
     unicode::explode_utf8(token, chars, code_points);
 
     std::string new_token;
+    new_token.reserve(chars.size());
 
     for (size_t i = 0; i < chars.size(); ++i)
     {
@@ -134,6 +151,53 @@ namespace onmt
     default:
       return Type::None;
     }
+  }
+
+  static bool placeholder_starts_with(const std::string& ph, const std::string& prefix)
+  {
+    size_t placeholder_length = (ph.length()
+                                 - Tokenizer::ph_marker_open.length()
+                                 - Tokenizer::ph_marker_close.length());
+    return (placeholder_length == prefix.length() + 1
+            && ph.compare(Tokenizer::ph_marker_open.length(), prefix.length(), prefix) == 0);
+  }
+
+  CaseModifier::Markup CaseModifier::get_case_markup(const std::string& str)
+  {
+    if (!Tokenizer::is_placeholder(str))
+      return Markup::None;
+    if (placeholder_starts_with(str, case_markup_prefix))
+      return Markup::Modifier;
+    if (placeholder_starts_with(str, case_markup_begin_prefix))
+      return Markup::RegionBegin;
+    if (placeholder_starts_with(str, case_markup_end_prefix))
+      return Markup::RegionEnd;
+    return Markup::None;
+  }
+
+  CaseModifier::Type CaseModifier::get_case_modifier_from_markup(const std::string& markup)
+  {
+    return char_to_type(markup[markup.length() - 1 - Tokenizer::ph_marker_close.length()]);
+  }
+
+  static std::string build_placeholder(const std::string& name)
+  {
+    return (Tokenizer::ph_marker_open + name + Tokenizer::ph_marker_close);
+  }
+
+  std::string CaseModifier::generate_case_markup(CaseModifier::Type type)
+  {
+    return build_placeholder(case_markup_prefix + type_to_char(type));
+  }
+
+  std::string CaseModifier::generate_case_markup_begin(CaseModifier::Type type)
+  {
+    return build_placeholder(case_markup_begin_prefix + type_to_char(type));
+  }
+
+  std::string CaseModifier::generate_case_markup_end(CaseModifier::Type type)
+  {
+    return build_placeholder(case_markup_end_prefix + type_to_char(type));
   }
 
 }

--- a/src/SentencePiece.cc
+++ b/src/SentencePiece.cc
@@ -87,19 +87,7 @@ namespace onmt
         new_token.spacer();
     }
 
-    if (token.is_joined_left())
-    {
-      tokens.front().join_left();
-      if (token.should_preserve())
-        tokens.front().preserve();
-    }
-    if (token.is_joined_right())
-    {
-      tokens.back().join_right();
-      if (token.should_preserve())
-        tokens.back().preserve();
-    }
-
+    propagate_token_properties(token, tokens);
     return tokens;
   }
 

--- a/src/SubwordEncoder.cc
+++ b/src/SubwordEncoder.cc
@@ -52,6 +52,13 @@ namespace onmt
         tokens.back().join_right();
     }
 
+    propagate_token_properties(token, tokens);
+    return tokens;
+  }
+
+  void SubwordEncoder::propagate_token_properties(const AnnotatedToken& token,
+                                                  std::vector<AnnotatedToken>& tokens)
+  {
     if (token.is_joined_left())
     {
       tokens.front().join_left();
@@ -65,9 +72,16 @@ namespace onmt
         tokens.back().preserve();
     }
 
-
-
-    return tokens;
+    if (token.has_case())
+    {
+      if (tokens.size() == 1 || token.get_case() == CaseModifier::Type::Capitalized)
+        tokens.front().set_case(token.get_case());
+      else
+      {
+        tokens.front().set_case_region_begin(token.get_case());
+        tokens.back().set_case_region_end(token.get_case());
+      }
+    }
   }
 
 }

--- a/test/test.cc
+++ b/test/test.cc
@@ -215,6 +215,44 @@ TEST(TokenizerTest, CaseFeature) {
            "test￨L \\￨N ￭\\￨N ￭\\￨N ￭\\￭￨N a￨L capitalized￨C lowercased￨L uppercasé￨U mixêd￨M -￨N cyrillic-б￨M");
 }
 
+TEST(TokenizerTest, CaseMarkupWithJoiners) {
+  Tokenizer tokenizer(Tokenizer::Mode::Conservative,
+                      Tokenizer::Flags::CaseMarkup | Tokenizer::Flags::JoinerAnnotate);
+  test_tok_and_detok(tokenizer,
+                     "Hello world!", "｟mrk_case_modifier_C｠ hello world ￭!");
+  test_tok_and_detok(tokenizer,
+                     "Hello WORLD!", "｟mrk_case_modifier_C｠ hello ｟mrk_begin_case_region_U｠ world ｟mrk_end_case_region_U｠ ￭!");
+  test_tok_and_detok(tokenizer,
+                     "Hello WOrld!", "｟mrk_case_modifier_C｠ hello ｟mrk_begin_case_region_U｠ wo￭ ｟mrk_end_case_region_U｠ rld ￭!");
+  test_tok_and_detok(tokenizer,
+                     "hello woRld!", "hello wo￭ ｟mrk_case_modifier_C｠ rld ￭!");
+}
+
+TEST(TokenizerTest, CaseMarkupWithSpacers) {
+  Tokenizer tokenizer(Tokenizer::Mode::Conservative,
+                      Tokenizer::Flags::CaseMarkup | Tokenizer::Flags::SpacerAnnotate);
+  test_tok_and_detok(tokenizer,
+                     "Hello world!", "｟mrk_case_modifier_C｠ hello ▁world !");
+  test_tok_and_detok(tokenizer,
+                     "Hello WORLD!", "｟mrk_case_modifier_C｠ hello ｟mrk_begin_case_region_U｠ ▁world ｟mrk_end_case_region_U｠ !");
+  test_tok_and_detok(tokenizer,
+                     "Hello WOrld!", "｟mrk_case_modifier_C｠ hello ｟mrk_begin_case_region_U｠ ▁wo ｟mrk_end_case_region_U｠ rld !");
+  test_tok_and_detok(tokenizer,
+                     "hello woRld!", "hello ▁wo ｟mrk_case_modifier_C｠ rld !");
+}
+
+TEST(TokenizerTest, CaseMarkupWithBPE) {
+  Tokenizer tokenizer(Tokenizer::Mode::Conservative,
+                      Tokenizer::Flags::CaseMarkup | Tokenizer::Flags::JoinerAnnotate,
+                      get_data("bpe-models/codes_suffix_case_insensitive.fr"));
+  test_tok_and_detok(tokenizer,
+                     "Bonjour monde", "｟mrk_case_modifier_C｠ bon￭ j￭ our mon￭ de");
+  test_tok_and_detok(tokenizer,
+                     "BONJOUR MONDE", "｟mrk_begin_case_region_U｠ bon￭ j￭ our ｟mrk_end_case_region_U｠ ｟mrk_begin_case_region_U｠ mon￭ de ｟mrk_end_case_region_U｠");
+  test_tok_and_detok(tokenizer,
+                     "BONJOUR monde", "｟mrk_begin_case_region_U｠ bon￭ j￭ our ｟mrk_end_case_region_U｠ mon￭ de");
+}
+
 TEST(TokenizerTest, SegmentCase) {
   Tokenizer tokenizer(Tokenizer::Mode::Conservative,
                       Tokenizer::Flags::CaseFeature | Tokenizer::Flags::JoinerAnnotate | Tokenizer::Flags::SegmentCase);


### PR DESCRIPTION
This PR adds a new `case_markup` option that injects case information as additional token and lowercases the input. The possible injected tokens are:

* `｟case_modifier_C｠`: capitalize the next token
* `｟case_modifier_U｠`: uppercase the next token
* `｟begin_case_region_U｠`: start an uppercase region
* `｟end_case_region_U｠`: terminate an uppercase region

Case regions are required when subword encoders is used. Otherwise 2 issues can arise:

1. Ambiguous detokenization:

* With subword: `WORLD` -> `｟case_modifier_U｠ wo￭ rld`
* Without subword: `WOrld` -> `｟case_modifier_U｠ wo￭ rld`

2. Subword sequence inconsistent with other cases:

* With subword: `WORLD` -> `｟case_modifier_U｠ wo￭ ｟case_modifier_U｠ rld`
* With subword: `world` -> `wo￭ rld`

Thus, it has been proposed to use opening and closing tags to remove the ambiguity:

```text
｟begin_case_region_U｠ wo￭ rld ｟end_case_region_U｠
```

In the current implementation, case regions do not overlap multiple tokens.