### PR TITLE
fix for std c++ conformance: ...begins with an underscore followed by…

### DIFF
--- a/src/BPELearner.cc
+++ b/src/BPELearner.cc
@@ -26,7 +26,7 @@ namespace onmt
   typedef std::pair<std::string, std::string> bigram;
   typedef std::vector<std::string> sequence;
 
-  std::string _S(const sequence &s) {
+  std::string _s(const sequence &s) {
     std::string t;
     for(const auto& w: s)
       t += ", u'" + w + "'";


### PR DESCRIPTION
Fix for code not conforming to C++ standard. "… an uppercase letter (2.11) is reserved to the implementation for any use." See [here](https://stackoverflow.com/questions/228783/what-are-the-rules-about-using-an-underscore-in-a-c-identifier) for more info. Most compilers don't complain about it, but on Cygwin using GCC, get this error when compiling:
 `src/BPELearner.cc:29:15: error: expected unqualified-id before numeric constant
   std::string _S(const sequence &s) {`