### PR TITLE
Optim tokbpe with combining

### DIFF
--- a/include/onmt/unicode/Unicode.h
+++ b/include/onmt/unicode/Unicode.h
@@ -23,8 +23,12 @@ namespace onmt
     OPENNMTTOKENIZER_EXPORT void
     explode_utf8_with_marks(const std::string& str,
                             std::vector<std::string>& chars,
-                            std::vector<std::vector<code_point_t>>& code_points,
+                            std::vector<code_point_t>& code_points_main,
+                            std::vector<std::vector<code_point_t>>& code_points_combining,
                             bool keep_code_points=true);
+    OPENNMTTOKENIZER_EXPORT void
+    explode_utf8_with_marks(const std::string& str,
+                            std::vector<std::string>& chars);
 
     OPENNMTTOKENIZER_EXPORT size_t utf8len(const std::string& str);
 

--- a/include/onmt/unicode/Unicode.h
+++ b/include/onmt/unicode/Unicode.h
@@ -23,7 +23,8 @@ namespace onmt
     OPENNMTTOKENIZER_EXPORT void
     explode_utf8_with_marks(const std::string& str,
                             std::vector<std::string>& chars,
-                            std::vector<std::vector<code_point_t>>& code_points);
+                            std::vector<std::vector<code_point_t>>& code_points,
+                            bool keep_code_points=true);
 
     OPENNMTTOKENIZER_EXPORT size_t utf8len(const std::string& str);
 

--- a/src/BPE.cc
+++ b/src/BPE.cc
@@ -107,9 +107,9 @@ namespace onmt
     std::vector<std::vector<unicode::code_point_t>> code_points;
 
     if (_case_insensitive)
-      unicode::explode_utf8_with_marks(CaseModifier::extract_case(str).first, chars, code_points);
+      unicode::explode_utf8_with_marks(CaseModifier::extract_case(str).first, chars, code_points, false);
     else
-      unicode::explode_utf8_with_marks(str, chars, code_points);
+      unicode::explode_utf8_with_marks(str, chars, code_points, false);
 
     if (chars.size() == 1)
     {

--- a/src/BPE.cc
+++ b/src/BPE.cc
@@ -104,12 +104,11 @@ namespace onmt
   std::vector<std::string> BPE::encode(const std::string& str) const
   {
     std::vector<std::string> chars;
-    std::vector<std::vector<unicode::code_point_t>> code_points;
 
     if (_case_insensitive)
-      unicode::explode_utf8_with_marks(CaseModifier::extract_case(str).first, chars, code_points, false);
+      unicode::explode_utf8_with_marks(CaseModifier::extract_case(str).first, chars);
     else
-      unicode::explode_utf8_with_marks(str, chars, code_points, false);
+      unicode::explode_utf8_with_marks(str, chars);
 
     if (chars.size() == 1)
     {

--- a/src/BPELearner.cc
+++ b/src/BPELearner.cc
@@ -252,8 +252,7 @@ namespace onmt
     std::multimap<int, sequence > charvocab;
     for(auto it = _vocab.begin(); it != _vocab.end(); it++) {
       sequence chars;
-      std::vector<std::vector<unicode::code_point_t>> code_points;
-      unicode::explode_utf8_with_marks(it->first, chars, code_points);
+      unicode::explode_utf8_with_marks(it->first, chars);
       chars.back().append("</w>");
       charvocab.insert(std::make_pair(-it->second, chars));
     }

--- a/src/Tokenizer.cc
+++ b/src/Tokenizer.cc
@@ -326,9 +326,10 @@ namespace onmt
     }
     else {
       std::vector<std::string> chars;
-      std::vector<std::vector<unicode::code_point_t>> code_points_seq;
+      std::vector<unicode::code_point_t> code_points_main;
+      std::vector<std::vector<unicode::code_point_t>> code_points_combining;
 
-      unicode::explode_utf8_with_marks(text, chars, code_points_seq);
+      unicode::explode_utf8_with_marks(text, chars, code_points_main, code_points_combining);
 
       AnnotatedToken token;
 
@@ -340,9 +341,9 @@ namespace onmt
       for (size_t i = 0; i < chars.size(); ++i)
       {
         const std::string& c = chars[i];
-        unicode::code_point_t v = code_points_seq[i].front();
-        unicode::code_point_t next_v = i + 1 < code_points_seq.size() ? code_points_seq[i + 1].front() : 0;
-        bool isSeparator = unicode::is_separator(v) && code_points_seq[i].size() == 1;
+        unicode::code_point_t v = code_points_main[i];
+        unicode::code_point_t next_v = i + 1 < code_points_main.size() ? code_points_main[i + 1] : 0;
+        bool isSeparator = unicode::is_separator(v) && code_points_combining[i].size() == 0;
 
         const bool letter = state & State::Letter;
         const bool space = state & State::Space;

--- a/src/unicode/Unicode.cc
+++ b/src/unicode/Unicode.cc
@@ -153,12 +153,14 @@ namespace onmt
 
     void explode_utf8_with_marks(const std::string& str,
                                  std::vector<std::string>& chars,
-                                 std::vector<std::vector<code_point_t>>& code_points)
+                                 std::vector<std::vector<code_point_t>>& code_points,
+                                 bool keep_code_points)
     {
       const char* c_str = str.c_str();
 
       chars.reserve(str.length());
-      code_points.reserve(str.length());
+      if (keep_code_points)
+        code_points.reserve(str.length());
 
       while (*c_str)
       {
@@ -171,10 +173,12 @@ namespace onmt
         }
         else
         {
-          code_points.emplace_back();
+          if (keep_code_points)
+            code_points.emplace_back();
           chars.emplace_back(c_str, char_size);
         }
-        code_points.back().push_back(code_point);
+        if (keep_code_points)
+          code_points.back().push_back(code_point);
         c_str += char_size;
       }
     }


### PR DESCRIPTION
this PR is to fix slowdown introduced in #59 and is separating structure from main code point and the structure from combining marks that was causing the overhead.

In my benchmark, performance is now on par with before #59 - can you please double-check?

We can push the idea a bit further and obtain a slight performance improvement from baseline when separating completely the 2 functions `explode_utf8_with_marks` - but this would make maintenance more complicated.

