### PR TITLE
Allow naming positional arguments in the Python API

### DIFF
--- a/bindings/python/Python.cc
+++ b/bindings/python/Python.cc
@@ -159,7 +159,8 @@ BOOST_PYTHON_MODULE(tokenizer)
   py::class_<TokenizerWrapper>(
       "Tokenizer",
       py::init<std::string, std::string, std::string, int, std::string, int, std::string, int, float, std::string, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, py::list>(
-        (py::arg("bpe_model_path")="",
+        (py::arg("mode"),
+         py::arg("bpe_model_path")="",
          py::arg("bpe_vocab_path")="",  // Keep for backward compatibility.
          py::arg("bpe_vocab_threshold")=50,  // Keep for backward compatibility.
          py::arg("vocabulary_path")="",
@@ -181,7 +182,9 @@ BOOST_PYTHON_MODULE(tokenizer)
          py::arg("segment_numbers")=false,
          py::arg("segment_alphabet_change")=false,
          py::arg("segment_alphabet")=py::list())))
-    .def("tokenize", &TokenizerWrapper::tokenize)
-    .def("detokenize", &TokenizerWrapper::detokenize, (py::arg("features")=py::object()))
+    .def("tokenize", &TokenizerWrapper::tokenize,
+         (py::arg("text")))
+    .def("detokenize", &TokenizerWrapper::detokenize,
+         (py::arg("tokens"), py::arg("features")=py::object()))
     ;
 }

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -36,7 +36,7 @@ tokenizer = pyonmt.Tokenizer(
     segment_alphabet_change=False,
     segment_alphabet=[])
 
-tokens, features = tokenizer.tokenize(test: str)
+tokens, features = tokenizer.tokenize(text: str)
 
 text = tokenizer.detokenize(tokens, features)
 text = tokenizer.detokenize(tokens)  # will fail if case_feature is set.

--- a/bindings/python/test/test.py
+++ b/bindings/python/test/test.py
@@ -14,3 +14,10 @@ def test_simple():
     assert features is None
     detok = tokenizer.detokenize(tokens)
     assert detok == text
+
+def test_named_arguments():
+    tokenizer = pyonmttok.Tokenizer(mode="aggressive", joiner_annotate=True)
+    text = "Hello World!"
+    tokens, features = tokenizer.tokenize(text=text)
+    assert tokens == ["Hello", "World", "￭!"]
+    assert text == tokenizer.detokenize(tokens=tokens)


### PR DESCRIPTION
Reported in #62.