### PR TITLE
Add method to get the annotated token representation

### DIFF
--- a/include/onmt/AnnotatedToken.h
+++ b/include/onmt/AnnotatedToken.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include "onmt/opennmttokenizer_export.h"
 #include "onmt/CaseModifier.h"
@@ -43,6 +44,11 @@ namespace onmt
     CaseModifier::Type get_case_region_begin() const;
     CaseModifier::Type get_case_region_end() const;
 
+    void set_features(const std::vector<std::string>& features);
+    void insert_feature(const std::string& feature);
+    bool has_features() const;
+    const std::vector<std::string>& features() const;
+
   private:
     std::string _str;
     CaseModifier::Type _case = CaseModifier::Type::None;
@@ -52,6 +58,7 @@ namespace onmt
     bool _join_right = false;
     bool _spacer = false;
     bool _preserved = false;
+    std::vector<std::string> _features;
   };
 
 }

--- a/include/onmt/BPELearner.h
+++ b/include/onmt/BPELearner.h
@@ -13,8 +13,8 @@ namespace onmt
   public:
     BPELearner(bool verbose,
                int symbols, int min_frequency, bool dict_input, bool total_symbols);
-    void ingest(std::istream &is, Tokenizer *pTokenizer=0);
-    void learn(std::ostream &os, const char *description=0);
+    void ingest(std::istream& is, const Tokenizer* tokenizer = 0);
+    void learn(std::ostream& os, const char* description = 0);
   private:
     int _symbols;
     int _min_frequency;

--- a/include/onmt/SPMLearner.h
+++ b/include/onmt/SPMLearner.h
@@ -20,7 +20,7 @@ namespace onmt
                const std::unordered_map<std::string, std::string>& opts,
                const std::string& input_filename);
 
-    void ingest(std::istream& is, Tokenizer* tokenizer = 0) override;
+    void ingest(std::istream& is, const Tokenizer* tokenizer = 0) override;
     void learn(std::ostream& os, const char* description = 0) override;
   private:
     std::string _args;

--- a/include/onmt/SubwordLearner.h
+++ b/include/onmt/SubwordLearner.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 #include <iostream>
@@ -14,12 +15,12 @@ namespace onmt
   {
   public:
     SubwordLearner(bool verbose);
-    virtual ~SubwordLearner();
-    virtual void ingest(std::istream &, Tokenizer *) = 0;
-    virtual void learn(std::ostream &, const char *) = 0;
+    virtual ~SubwordLearner() = default;
+    virtual void ingest(std::istream& in, const Tokenizer* tokenizer) = 0;
+    virtual void learn(std::ostream& out, const char* description) = 0;
   protected:
     bool _verbose;
-    Tokenizer *_pTokDefault;
+    std::unique_ptr<const Tokenizer> _default_tokenizer;
   };
 
 }

--- a/include/onmt/Tokenizer.h
+++ b/include/onmt/Tokenizer.h
@@ -86,6 +86,12 @@ namespace onmt
                   std::vector<std::vector<std::string> >& features,
                   std::unordered_map<std::string, size_t>& alphabets) const override;
 
+    void tokenize(const std::string& text,
+                  std::vector<AnnotatedToken>& annotated_tokens) const;
+    void finalize_tokens(std::vector<AnnotatedToken>& annotated_tokens,
+                         std::vector<std::string>& tokens,
+                         std::vector<std::vector<std::string>>& features) const;
+
     std::string detokenize(const std::vector<std::string>& words,
                            const std::vector<std::vector<std::string> >& features) const override;
     std::string detokenize(const std::vector<std::string>& words,
@@ -134,10 +140,10 @@ namespace onmt
 
     void read_flags(int flags);
     std::vector<AnnotatedToken> encode_subword(const std::vector<AnnotatedToken>& tokens) const;
-    void finalize_tokens(std::vector<AnnotatedToken>& annotated_tokens,
-                         std::vector<std::string>& tokens,
-                         std::vector<std::vector<std::string>>& features) const;
 
+    void tokenize(const std::string& text,
+                  std::vector<AnnotatedToken>& annotated_tokens,
+                  std::unordered_map<std::string, size_t>* alphabets) const;
     void tokenize(const std::string& text,
                   std::vector<std::string>& words,
                   std::vector<std::vector<std::string> >& features,

--- a/include/onmt/Tokenizer.h
+++ b/include/onmt/Tokenizer.h
@@ -135,7 +135,8 @@ namespace onmt
     void read_flags(int flags);
     std::vector<AnnotatedToken> encode_subword(const std::vector<AnnotatedToken>& tokens) const;
     void finalize_tokens(std::vector<AnnotatedToken>& annotated_tokens,
-                         std::vector<std::string>& tokens) const;
+                         std::vector<std::string>& tokens,
+                         std::vector<std::vector<std::string>>& features) const;
 
     void tokenize(const std::string& text,
                   std::vector<std::string>& words,

--- a/src/AnnotatedToken.cc
+++ b/src/AnnotatedToken.cc
@@ -131,4 +131,24 @@ namespace onmt
     return _end_case_region;
   }
 
+  void AnnotatedToken::set_features(const std::vector<std::string>& features)
+  {
+    _features = features;
+  }
+
+  void AnnotatedToken::insert_feature(const std::string& feature)
+  {
+    _features.push_back(feature);
+  }
+
+  bool AnnotatedToken::has_features() const
+  {
+    return !_features.empty();
+  }
+
+  const std::vector<std::string>& AnnotatedToken::features() const
+  {
+    return _features;
+  }
+
 }

--- a/src/BPELearner.cc
+++ b/src/BPELearner.cc
@@ -40,10 +40,9 @@ namespace onmt
               _dict_input(dict_input), _total_symbols(total_symbols) {
   }
 
-  void BPELearner::ingest(std::istream &is, Tokenizer *pTok) {
-    if (!pTok)
-      pTok = this->_pTokDefault;
-    pTok->unset_annotate();
+  void BPELearner::ingest(std::istream& is, const Tokenizer* tokenizer) {
+    if (!tokenizer)
+      tokenizer = _default_tokenizer.get();
     // get_vocabulary - builds vocabulary from file or dictionary
     while (!is.eof()) {
       std::string line;
@@ -57,12 +56,11 @@ namespace onmt
           }
           _vocab[line.substr(0, p)] += std::stoi(line.substr(p+1));
         } else {
-          sequence words;
-          std::vector<sequence> features;
-          pTok->tokenize(line, words, features);
-          for(const auto& w: words) {
-            if (!Tokenizer::is_placeholder(w))
-              _vocab[w]++;
+          std::vector<AnnotatedToken> tokens;
+          tokenizer->tokenize(line, tokens);
+          for(const auto& token : tokens) {
+            if (!Tokenizer::is_placeholder(token.str()))
+              _vocab[token.str()]++;
           }
         }
       }

--- a/src/SPMLearner.cc
+++ b/src/SPMLearner.cc
@@ -39,7 +39,7 @@ namespace onmt
       _args += " --" + pair.first + "=" + pair.second;
   }
 
-  void SPMLearner::ingest(std::istream& is, Tokenizer* tokenizer)
+  void SPMLearner::ingest(std::istream& is, const Tokenizer* tokenizer)
   {
     if (!_input_stream)
       _input_stream.reset(new std::ofstream(_input_filename));
@@ -51,13 +51,12 @@ namespace onmt
         *_input_stream << line << std::endl;
       else
       {
-        std::vector<std::string> tokens;
-        std::vector<std::vector<std::string>> features;
-        tokenizer->tokenize(line, tokens, features);
+        std::vector<AnnotatedToken> tokens;
+        tokenizer->tokenize(line, tokens);
         for (const auto& token : tokens)
         {
-          if (!Tokenizer::is_placeholder(token))
-            *_input_stream << token << std::endl;
+          if (!Tokenizer::is_placeholder(token.str()))
+            *_input_stream << token.str() << std::endl;
         }
       }
     }

--- a/src/SubwordEncoder.cc
+++ b/src/SubwordEncoder.cc
@@ -74,9 +74,17 @@ namespace onmt
 
     if (token.has_case())
     {
-      if (tokens.size() == 1 || token.get_case() == CaseModifier::Type::Capitalized)
-        tokens.front().set_case(token.get_case());
-      else
+      for (size_t i = 0; i < tokens.size(); ++i)
+      {
+        auto case_type = token.get_case();
+        if (case_type == CaseModifier::Type::Capitalized && i > 0)
+          case_type = CaseModifier::Type::Lowercase;
+        else if (case_type == CaseModifier::Type::Mixed)
+          case_type = CaseModifier::extract_case_type(tokens[i].str()).second;
+        tokens[i].set_case(case_type);
+      }
+
+      if (token.begin_case_region())
       {
         tokens.front().set_case_region_begin(token.get_case());
         tokens.back().set_case_region_end(token.get_case());

--- a/src/SubwordEncoder.cc
+++ b/src/SubwordEncoder.cc
@@ -90,6 +90,12 @@ namespace onmt
         tokens.back().set_case_region_end(token.get_case());
       }
     }
+
+    if (token.has_features())
+    {
+      for (auto& sub_token : tokens)
+        sub_token.set_features(token.features());
+    }
   }
 
 }

--- a/src/SubwordLearner.cc
+++ b/src/SubwordLearner.cc
@@ -4,13 +4,10 @@
 namespace onmt
 {
 
-  SubwordLearner::SubwordLearner(bool verbose):
-        _verbose(verbose) {
-    _pTokDefault = new Tokenizer(onmt::Tokenizer::mapMode.at("space"));
-  }
-
-  SubwordLearner::~SubwordLearner() {
-    delete _pTokDefault;
+  SubwordLearner::SubwordLearner(bool verbose)
+    : _verbose(verbose)
+    , _default_tokenizer(new Tokenizer(onmt::Tokenizer::mapMode.at("space")))
+  {
   }
 
 }


### PR DESCRIPTION
The current methods can only return the final token string representation which for example includes joiner and spacers. It is sometimes useful to get the intermediate annotated representation instead. Typically subword learning should ignore joiners/spacers and the current approach to call `unset_annotate` was a bit hacky.