### PR TITLE
Add threading to stream tokenization

### DIFF
--- a/bindings/python/Python.cc
+++ b/bindings/python/Python.cc
@@ -201,6 +201,23 @@ public:
     return _tokenizer->detokenize(words_vec, features_vec);
   }
 
+  void tokenize_file(const std::string& input_path,
+                     const std::string& output_path,
+                     int num_threads)
+  {
+    std::ifstream in(input_path);
+    std::ofstream out(output_path);
+    _tokenizer->tokenize_stream(in, out, num_threads);
+  }
+
+  void detokenize_file(const std::string& input_path,
+                       const std::string& output_path)
+  {
+    std::ifstream in(input_path);
+    std::ofstream out(output_path);
+    _tokenizer->detokenize_stream(in, out);
+  }
+
   const std::shared_ptr<const onmt::Tokenizer> get() const
   {
     return _tokenizer;
@@ -362,10 +379,17 @@ PYBIND11_MODULE(pyonmttok, m)
          py::arg("segment_alphabet_change")=false,
          py::arg("segment_alphabet")=py::list())
     .def("tokenize", &TokenizerWrapper::tokenize, py::arg("text"))
+    .def("tokenize_file", &TokenizerWrapper::tokenize_file,
+         py::arg("input_path"),
+         py::arg("output_path"),
+         py::arg("num_threads")=1)
     .def("detokenize", &TokenizerWrapper::detokenize,
          py::arg("tokens"), py::arg("features")=py::none())
     .def("detokenize_with_ranges", &TokenizerWrapper::detokenize_with_ranges,
          py::arg("tokens"), py::arg("merge_ranges")=false)
+    .def("detokenize_file", &TokenizerWrapper::detokenize_file,
+         py::arg("input_path"),
+         py::arg("output_path"))
     .def("__copy__", copy<TokenizerWrapper>)
     .def("__deepcopy__", deepcopy<TokenizerWrapper>)
     ;

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -43,6 +43,10 @@ text = tokenizer.detokenize(tokens)  # will fail if case_feature is set.
 # the detokenized text. Set merge_ranges=True to merge consecutive ranges, e.g.
 # subwords of the same token in case of subword tokenization.
 text, ranges = tokenizer.detokenize_with_ranges(tokens, merge_ranges=True)
+
+# File-based APIs
+tokenizer.tokenize_file(input_path: str, output_path: str, num_threads=1)
+tokenizer.detokenize_file(input_path: str, output_path: str)
 ```
 
 See the [documentation](../../docs/options.md) for a description of each option.

--- a/bindings/python/test/test.py
+++ b/bindings/python/test/test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import os
 import copy
 import pytest
 import pyonmttok
@@ -15,6 +16,22 @@ def test_simple():
     assert features is None
     detok = tokenizer.detokenize(tokens)
     assert detok == text
+
+def test_file(tmpdir):
+    input_path = str(tmpdir.join("input.txt"))
+    output_path = str(tmpdir.join("output.txt"))
+    with open(input_path, "w") as input_file:
+        input_file.write("Hello world!")
+    tokenizer = pyonmttok.Tokenizer("aggressive", joiner_annotate=True, joiner_new=True)
+    tokenizer.tokenize_file(input_path, output_path)
+    assert os.path.exists(output_path)
+    with open(output_path) as output_file:
+        assert output_file.readline().strip() == "Hello world ￭ !"
+    os.remove(input_path)
+    tokenizer.detokenize_file(output_path, input_path)
+    assert os.path.exists(input_path)
+    with open(input_path) as input_file:
+        assert input_file.readline().strip() == "Hello world!"
 
 def test_custom_joiner():
     tokenizer = pyonmttok.Tokenizer(

--- a/cli/detokenize.cc
+++ b/cli/detokenize.cc
@@ -33,20 +33,11 @@ int main(int argc, char* argv[])
   if (vm["spacer_annotate"].as<bool>())
     flags |= onmt::Tokenizer::Flags::SpacerAnnotate;
 
-  onmt::ITokenizer* tokenizer = new onmt::Tokenizer(onmt::Tokenizer::Mode::Conservative,
-                                                    flags,
-                                                    "",
-                                                    vm["joiner"].as<std::string>());
+  onmt::Tokenizer tokenizer(onmt::Tokenizer::Mode::Conservative,
+                            flags,
+                            "",
+                            vm["joiner"].as<std::string>());
 
-  std::string line;
-
-  while (std::getline(std::cin, line))
-  {
-    if (!line.empty())
-      std::cout << tokenizer->detokenize(line);
-
-    std::cout << std::endl;
-  }
-
+  tokenizer.detokenize_stream(std::cin, std::cout);
   return 0;
 }

--- a/cli/tokenize.cc
+++ b/cli/tokenize.cc
@@ -35,6 +35,7 @@ int main(int argc, char* argv[])
     ("bpe_vocab_threshold", po::value<int>()->default_value(50), "Depracted, see --vocabulary_threshold.")
     ("vocabulary", po::value<std::string>()->default_value(""), "Vocabulary file. If provided, sentences are encoded to subword present in this vocabulary.")
     ("vocabulary_threshold", po::value<int>()->default_value(0), "Vocabulary threshold. If vocabulary is provided, any word with frequency < threshold will be treated as OOV.")
+    ("num_threads", po::value<int>()->default_value(1), "Number of threads to use.")
 #ifdef WITH_SP
     ("sp_model,sp", po::value<std::string>()->default_value(""), "path to the SentencePiece model")
     ("sp_nbest_size", po::value<int>()->default_value(0), "number of candidates for the SentencePiece sampling API")
@@ -119,15 +120,6 @@ int main(int argc, char* argv[])
       std::cerr << "WARNING: " << alphabet << " alphabet is not supported" << std::endl;
   }
 
-  std::string line;
-
-  while (std::getline(std::cin, line))
-  {
-    if (!line.empty())
-      std::cout << tokenizer.tokenize(line);
-
-    std::cout << std::endl;
-  }
-
+  tokenizer.tokenize_stream(std::cin, std::cout, vm["num_threads"].as<int>());
   return 0;
 }

--- a/include/onmt/ITokenizer.h
+++ b/include/onmt/ITokenizer.h
@@ -51,7 +51,6 @@ namespace onmt
                                  size_t buffer_size = 1000) const;
 
     virtual void detokenize_stream(std::istream& is, std::ostream& os) const;
-
   };
 
 }

--- a/include/onmt/ITokenizer.h
+++ b/include/onmt/ITokenizer.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <string>
 #include <unordered_map>
+#include <iostream>
 
 #include "onmt/opennmttokenizer_export.h"
 
@@ -43,6 +44,14 @@ namespace onmt
 
     // Split the text on spaces and detokenize.
     virtual std::string detokenize(const std::string& text) const;
+
+    virtual void tokenize_stream(std::istream& is,
+                                 std::ostream& os,
+                                 size_t num_threads = 1,
+                                 size_t buffer_size = 1000) const;
+
+    virtual void detokenize_stream(std::istream& is, std::ostream& os) const;
+
   };
 
 }

--- a/src/ITokenizer.cc
+++ b/src/ITokenizer.cc
@@ -1,11 +1,118 @@
 #include "onmt/ITokenizer.h"
 
+#include <future>
+#include <mutex>
+#include <queue>
+#include <thread>
+
 #include "onmt/SpaceTokenizer.h"
 
 namespace onmt
 {
 
   const std::string ITokenizer::feature_marker("￨");
+
+
+  template <typename Function>
+  void work_loop(const Function& function,
+                 std::queue<std::pair<std::promise<std::string>, std::string>>& queue,
+                 std::mutex& mutex,
+                 std::condition_variable& cv,
+                 const bool& end_requested)
+  {
+    while (true)
+    {
+      std::unique_lock<std::mutex> lock(mutex);
+      cv.wait(lock, [&queue, &end_requested]{
+        return !queue.empty() || end_requested;
+      });
+
+      if (end_requested)
+      {
+        lock.unlock();
+        break;
+      }
+
+      auto work = std::move(queue.front());
+      queue.pop();
+      lock.unlock();
+
+      auto& promise = work.first;
+      auto& text = work.second;
+      promise.set_value(function(text));
+    }
+  }
+
+  template <typename Function>
+  void process_stream(const Function& function,
+                      std::istream& in,
+                      std::ostream& out,
+                      size_t num_threads,
+                      size_t buffer_size)
+  {
+    std::string line;
+    if (num_threads <= 1) // Fast path for sequential processing.
+    {
+      while (std::getline(in, line))
+        out << function(line) << std::endl;
+      return;
+    }
+
+    std::queue<std::pair<std::promise<std::string>, std::string>> queue;
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool request_end = false;
+
+    std::vector<std::thread> workers;
+    workers.reserve(num_threads);
+    for (size_t i = 0; i < num_threads; ++i)
+      workers.emplace_back(&work_loop<Function>,
+                           std::cref(function),
+                           std::ref(queue),
+                           std::ref(mutex),
+                           std::ref(cv),
+                           std::cref(request_end));
+
+    std::queue<std::future<std::string>> futures;
+
+    auto pop_results = [&futures, &out](bool blocking) {
+      static const auto zero_sec = std::chrono::seconds(0);
+      while (!futures.empty()
+             && (blocking
+                 || futures.front().wait_for(zero_sec) == std::future_status::ready)) {
+        out << futures.front().get() << std::endl;
+        futures.pop();
+      }
+    };
+
+    while (std::getline(in, line))
+    {
+      {
+        std::lock_guard<std::mutex> lock(mutex);
+        queue.emplace(std::piecewise_construct,
+                      std::forward_as_tuple(),
+                      std::forward_as_tuple(std::move(line)));
+        futures.emplace(queue.back().first.get_future());
+      }
+
+      cv.notify_one();
+      if (futures.size() >= buffer_size)
+        pop_results(/*blocking=*/false);
+    }
+
+    if (!futures.empty())
+      pop_results(/*blocking=*/true);
+
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      request_end = true;
+    }
+
+    cv.notify_all();
+    for (auto& worker : workers)
+      worker.join();
+  }
+
 
   void ITokenizer::tokenize(const std::string& text,
                             std::vector<std::string>& words,
@@ -59,6 +166,21 @@ namespace onmt
                                      Ranges&, bool) const
   {
     return detokenize(words, features);
+  }
+
+  void ITokenizer::tokenize_stream(std::istream& in,
+                                   std::ostream& out,
+                                   size_t num_threads,
+                                   size_t buffer_size) const
+  {
+    auto function = [this](const std::string& text) { return this->tokenize(text); };
+    process_stream(function, in, out, num_threads, buffer_size);
+  }
+
+  void ITokenizer::detokenize_stream(std::istream& in, std::ostream& out) const
+  {
+    auto function = [this](const std::string& text) { return this->detokenize(text); };
+    process_stream(function, in, out, /*num_threads=*/1, /*buffer_size=*/0);
   }
 
 }


### PR DESCRIPTION
This PR moves the stream processing API inside the library and adds threading support for tokenization. Detokenization will remain sequential as it is mostly I/O bound.

Closes #71.