### PR TITLE
Support prior joiners

### DIFF
--- a/bindings/python/Python.cc
+++ b/bindings/python/Python.cc
@@ -384,6 +384,7 @@ PYBIND11_MODULE(pyonmttok, m)
          py::arg("segment_case")=false,
          py::arg("segment_numbers")=false,
          py::arg("segment_alphabet_change")=false,
+         py::arg("support_prior_joiners")=false,
          py::arg("segment_alphabet")=py::list())
     .def("tokenize", &TokenizerWrapper::tokenize, py::arg("text"))
     .def("tokenize_file", &TokenizerWrapper::tokenize_file,

--- a/bindings/python/Python.cc
+++ b/bindings/python/Python.cc
@@ -361,7 +361,7 @@ private:
 PYBIND11_MODULE(pyonmttok, m)
 {
   py::class_<TokenizerWrapper>(m, "Tokenizer")
-    .def(py::init<std::string, std::string, std::string, int, std::string, int, std::string, int, float, std::string, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, py::list>(),
+    .def(py::init<std::string, std::string, std::string, int, std::string, int, std::string, int, float, std::string, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, py::list>(),
          py::arg("mode"),
          py::arg("bpe_model_path")="",
          py::arg("bpe_vocab_path")="",  // Keep for backward compatibility.

--- a/bindings/python/Python.cc
+++ b/bindings/python/Python.cc
@@ -94,6 +94,7 @@ public:
                    bool segment_case,
                    bool segment_numbers,
                    bool segment_alphabet_change,
+                   bool support_prior_joiners,
                    py::list segment_alphabet)
   {
     onmt::SubwordEncoder* subword_encoder = nullptr;
@@ -138,6 +139,8 @@ public:
       flags |= onmt::Tokenizer::Flags::SegmentNumbers;
     if (segment_alphabet_change)
       flags |= onmt::Tokenizer::Flags::SegmentAlphabetChange;
+    if (support_prior_joiners)
+      flags |= onmt::Tokenizer::Flags::SupportPriorJoiners;
 
     auto tokenizer = new onmt::Tokenizer(onmt::Tokenizer::str_to_mode(mode),
                                          subword_encoder,

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -32,6 +32,7 @@ tokenizer = pyonmttok.Tokenizer(
     segment_case=False,
     segment_numbers=False,
     segment_alphabet_change=False,
+    support_prior_joiners=False,
     segment_alphabet=[])
 
 tokens, features = tokenizer.tokenize(text: str)

--- a/cli/tokenize.cc
+++ b/cli/tokenize.cc
@@ -43,6 +43,7 @@ int main(int argc, char* argv[])
     ("sp_nbest_size", po::value<int>()->default_value(0), "number of candidates for the SentencePiece sampling API")
     ("sp_alpha", po::value<float>()->default_value(0.1), "smoothing parameter for the SentencePiece sampling API")
 #endif
+    ("support_prior_joiners", po::bool_switch()->default_value(false), "if text has existing joiner marks, keep them")
     ;
 
   po::variables_map vm;
@@ -111,6 +112,9 @@ int main(int argc, char* argv[])
                                                     vm["sp_alpha"].as<float>()));
   }
 #endif
+
+  if (vm["support_prior_joiners"].as<bool>())
+    flags |= onmt::Tokenizer::Flags::SupportPriorJoiners;
 
   if (subword_encoder && !vocabulary.empty())
     subword_encoder->load_vocabulary(vocabulary, vocabulary_threshold);

--- a/cli/tokenize.cc
+++ b/cli/tokenize.cc
@@ -30,6 +30,7 @@ int main(int argc, char* argv[])
     ("segment_numbers", po::bool_switch()->default_value(false), "Segment numbers into single digits")
     ("segment_alphabet", po::value<std::string>()->default_value(""), "comma-separated list of alphabets on which to segment all letters.")
     ("segment_alphabet_change", po::bool_switch()->default_value(false), "Segment if the alphabet changes between 2 letters.")
+    ("support_prior_joiners", po::bool_switch()->default_value(false), "if text has existing joiner marks, keep them")
     ("bpe_model_path", po::value<std::string>(), "Path to the BPE model")
     ("bpe_model,b", po::value<std::string>()->default_value(""), "Aliases for --bpe_model_path")
     ("bpe_vocab", po::value<std::string>()->default_value(""), "Deprecated, see --vocabulary.")
@@ -43,7 +44,6 @@ int main(int argc, char* argv[])
     ("sp_nbest_size", po::value<int>()->default_value(0), "number of candidates for the SentencePiece sampling API")
     ("sp_alpha", po::value<float>()->default_value(0.1), "smoothing parameter for the SentencePiece sampling API")
 #endif
-    ("support_prior_joiners", po::bool_switch()->default_value(false), "if text has existing joiner marks, keep them")
     ;
 
   po::variables_map vm;
@@ -79,6 +79,8 @@ int main(int argc, char* argv[])
     flags |= onmt::Tokenizer::Flags::SegmentNumbers;
   if (vm["segment_alphabet_change"].as<bool>())
     flags |= onmt::Tokenizer::Flags::SegmentAlphabetChange;
+  if (vm["support_prior_joiners"].as<bool>())
+    flags |= onmt::Tokenizer::Flags::SupportPriorJoiners;
 
   std::vector<std::string> alphabets_to_segment;
   boost::split(alphabets_to_segment,
@@ -112,9 +114,6 @@ int main(int argc, char* argv[])
                                                     vm["sp_alpha"].as<float>()));
   }
 #endif
-
-  if (vm["support_prior_joiners"].as<bool>())
-    flags |= onmt::Tokenizer::Flags::SupportPriorJoiners;
 
   if (subword_encoder && !vocabulary.empty())
     subword_encoder->load_vocabulary(vocabulary, vocabulary_threshold);

--- a/docs/options.md
+++ b/docs/options.md
@@ -241,3 +241,13 @@ $ echo "測試abc" | cli/tokenize --segment_alphabet Han --segment_alphabet_chan
     --joiner_annotate --preserve_segmented_tokens
 測 ￭ 試 ￭ abc
 ```
+
+### `support_prior_joiners`(boolean, default: `false`)
+
+If the input already has joiners, support these joiners as pre-tokenization marks.
+
+```bash
+$ echo "pre￭ tokenization." | cli/tokenize --joiner_annotate --support_prior_joiners \
+   --mode aggressive
+pre￭ tokenization ￭.
+```

--- a/include/onmt/Tokenizer.h
+++ b/include/onmt/Tokenizer.h
@@ -42,6 +42,7 @@ namespace onmt
       SpacerNew = 1 << 13,
       PreserveSegmentedTokens = 1 << 14,
       CaseMarkup = 1 << 15,
+      SupportPriorJoiners = 1 << 16
     };
 
     static const std::string joiner_marker;
@@ -136,6 +137,7 @@ namespace onmt
     bool _spacer_new;
     bool _preserve_placeholders;
     bool _preserve_segmented_tokens;
+    bool _support_prior_joiners;
 
     const SubwordEncoder* _subword_encoder;
     std::string _joiner;

--- a/src/Tokenizer.cc
+++ b/src/Tokenizer.cc
@@ -421,18 +421,23 @@ namespace onmt
   static void _tokenizeByPlaceholder(const std::string &text,
                                      std::vector<AnnotatedToken> &annotated_tokens,
                                      bool preserve_placeholders) {
+    size_t initial_tokens_count = annotated_tokens.size();
     size_t q = 0;
     while (1) {
       if (q != 0 && text[q] != ' ')
         annotated_tokens.back().join_right();
       size_t p = text.find(Tokenizer::ph_marker_open, q);
       if (p == std::string::npos) {
-        annotated_tokens.emplace_back(text.substr(q));
+        /* do not add empty token at the end */
+        if (q != text.size())
+          annotated_tokens.emplace_back(text.substr(q));
         break;
       }
       if (p != q)
         annotated_tokens.emplace_back(text.substr(q, p-q));
-      if (annotated_tokens.size() && !_endsWithSpace(annotated_tokens.back().str()))
+      /* do not add joiner on tokens analyzed before this call */
+      if (annotated_tokens.size() > initial_tokens_count
+          && !_endsWithSpace(annotated_tokens.back().str()))
         annotated_tokens.back().join_right();
       q = text.find(Tokenizer::ph_marker_close, p);
       if (q == std::string::npos) {

--- a/src/Tokenizer.cc
+++ b/src/Tokenizer.cc
@@ -518,7 +518,6 @@ namespace onmt
         for (size_t i = 1; i < fields.size(); ++i)
           annotated_tokens.back().insert_feature(fields[i]);
       }
-
     }
     else {
       std::vector<std::string> chars;

--- a/test/test.cc
+++ b/test/test.cc
@@ -524,10 +524,10 @@ TEST(TokenizerTest, CharMode) {
 }
 
 TEST(TokenizerTest, PriorJoinerSupportSpace) {
-  Tokenizer tokenizer(Tokenizer::Mode::Space, Tokenizer::Flags::JoinerAnnotate | Tokenizer::Flags::SupportPriorJoiners);
+  Tokenizer tokenizer(Tokenizer::Mode::Space, Tokenizer::Flags::JoinerAnnotate | Tokenizer::Flags::SupportPriorJoiners | Tokenizer::Flags::PreservePlaceholders);
   test_tok(tokenizer,
-           "It is a test-aggressive ￭'￭ with pre￭ tokenizat ￭ions World￭ 123.",
-           "It is a test-aggressive ￭'￭ with pre￭ tokenizat ￭ions World￭ 123.");
+           "It is a test-aggressive ￭'￭ with pre￭ tokenizat ￭ions World￭ 123 and double ￭｟mrk_place｠｟mrk_holder｠￭ .",
+           "It is a test-aggressive ￭'￭ with pre￭ tokenizat ￭ions World￭ 123 and double ￭ ｟mrk_place｠ ￭ ｟mrk_holder｠ ￭ .");
 }
 
 TEST(TokenizerTest, NormalizeJoinerSpace) {

--- a/test/test.cc
+++ b/test/test.cc
@@ -523,6 +523,27 @@ TEST(TokenizerTest, CharMode) {
   test_tok(tokenizer, "  Hello   World 123.", "H e l l o W o r l d 1 2 3 .");
 }
 
+TEST(TokenizerTest, PriorJoinerSupportSpace) {
+  Tokenizer tokenizer(Tokenizer::Mode::Space, Tokenizer::Flags::JoinerAnnotate | Tokenizer::Flags::SupportPriorJoiners);
+  test_tok(tokenizer,
+           "It is a test-aggressive ￭'￭ with pre￭ tokenizat ￭ions World￭ 123.",
+           "It is a test-aggressive ￭'￭ with pre￭ tokenizat ￭ions World￭ 123.");
+}
+
+TEST(TokenizerTest, NormalizeJoinerSpace) {
+  Tokenizer tokenizer(Tokenizer::Mode::Space, Tokenizer::Flags::JoinerAnnotate);
+  test_tok(tokenizer,
+           "It is a test-aggressive ■'■ with pre￭ tokenizat ■ions World■ 123.",
+           "It is a test-aggressive ■'■ with pre■ tokenizat ■ions World■ 123.");
+}
+
+TEST(TokenizerTest, PriorJoinerSupport) {
+  Tokenizer tokenizer(Tokenizer::Mode::Aggressive, Tokenizer::Flags::JoinerAnnotate | Tokenizer::Flags::SupportPriorJoiners);
+  test_tok(tokenizer,
+           "It is a test-aggressive ￭'￭ with pre￭ tokenizat ￭ions World￭ 123.",
+           "It is a test ￭-￭ aggressive ￭'￭ with pre￭ tokenizat ￭ions World￭ 123 ￭.");
+}
+
 TEST(TokenizerTest, CharModeSpacer) {
   Tokenizer tokenizer(Tokenizer::Mode::Char, Tokenizer::Flags::SpacerAnnotate);
   test_tok(tokenizer, "  Hello   World 123.", "H e l l o ▁W o r l d ▁1 2 3 .");


### PR DESCRIPTION
implement new tokenisation option allowing to support joiners present in input string. This is interesting to combine multiple tokenization - or performed a pre-tokenization with a pre-process.

The PR also fix substitution of special characters that was not performed for `space` tokenization mode.