### PR TITLE
Do not normalize characters in placeholders during space tokenization

### DIFF
--- a/include/onmt/Tokenizer.h
+++ b/include/onmt/Tokenizer.h
@@ -147,6 +147,8 @@ namespace onmt
     void read_flags(int flags);
     std::vector<AnnotatedToken> encode_subword(const std::vector<AnnotatedToken>& tokens) const;
 
+    void tokenize_on_placeholders(const std::string& text,
+                                  std::vector<AnnotatedToken>& annotated_tokens) const;
     void tokenize(const std::string& text,
                   std::vector<AnnotatedToken>& annotated_tokens,
                   std::unordered_map<std::string, size_t>* alphabets) const;

--- a/test/test.cc
+++ b/test/test.cc
@@ -551,8 +551,8 @@ TEST(TokenizerTest, PriorJoinerSupportSpace) {
 TEST(TokenizerTest, NormalizeJoinerSpace) {
   Tokenizer tokenizer(Tokenizer::Mode::Space, Tokenizer::Flags::JoinerAnnotate);
   test_tok(tokenizer,
-           "It is a test-aggressive ■'■ with pre￭ tokenizat ■ions World■ 123.",
-           "It is a test-aggressive ■'■ with pre■ tokenizat ■ions World■ 123.");
+           "It is a test-aggressive ■'■ with pre￭ tokenizat ■ions ｟entity＃1：World￭｠ 123.",
+           "It is a test-aggressive ■'■ with pre■ tokenizat ■ions ｟entity＃1：World￭｠ 123.");
 }
 
 TEST(TokenizerTest, PriorJoinerSupport) {


### PR DESCRIPTION
@jsenellart, FYI about this regression.

I had an easier time fixing this by refactoring the tokenization on placeholders as an explicit tokenization loop (i.e. iterating over characters). The logic should be easier to follow.