### PR TITLE
Revert "Use ICU for UTF8 to code point conversion"

### DIFF
--- a/src/unicode/Unicode.cc
+++ b/src/unicode/Unicode.cc
@@ -69,19 +69,6 @@ namespace onmt
 
     code_point_t utf8_to_cp(const unsigned char* s, unsigned int &l)
     {
-#ifdef WITH_ICU
-      UChar32 c;
-      int32_t offset = 0;
-      U8_NEXT(s, offset, -1, c);
-      if (c < 0)
-      {
-        l = 0;
-        c = 0;
-      }
-      else
-        l = offset;
-      return c;
-#else
       if (*s == 0 || *s >= 0xfe)
         return 0;
       if (*s <= 0x7f)
@@ -113,7 +100,6 @@ namespace onmt
       }
 
       return 0; // Incorrect unicode
-#endif
     }
 
     std::vector<std::string> split_utf8(const std::string& str, const std::string& sep)


### PR DESCRIPTION
Reverts OpenNMT/Tokenizer#87

For unclear reasons, this was found to cause memory issues in a multi threaded context with ICU 57.1.