### PR TITLE
add missing include <stdexcept> required by std::invalid_argument

### DIFF
--- a/src/SentencePiece.cc
+++ b/src/SentencePiece.cc
@@ -1,6 +1,7 @@
 #include "onmt/SentencePiece.h"
 
 #include <sentencepiece_processor.h>
+#include <stdexcept>
 
 namespace onmt
 {


### PR DESCRIPTION
This PR adds an include to `<stdexcept>`, which is required by `std::invalid_argument` and `std::runtime_error`. Visual Studio build fails without it when the `SentencePiece` library is found.