### PR TITLE
Always ignore placeholders when learning subword models

### DIFF
--- a/include/onmt/BPELearner.h
+++ b/include/onmt/BPELearner.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <memory>
-#include <string>
 #include <unordered_map>
 
 #include "onmt/opennmttokenizer_export.h"
@@ -14,16 +12,17 @@ namespace onmt
   public:
     BPELearner(bool verbose,
                int symbols, int min_frequency, bool dict_input, bool total_symbols);
-    void ingest(const std::string& text, const Tokenizer* tokenizer = nullptr) override;
     void ingest(std::istream& is, const Tokenizer* tokenizer = nullptr) override;
     void learn(std::ostream& os, const char* description = 0, bool verbose = false) override;
+  protected:
+    void ingest_token(const std::string& token) override;
   private:
+    void load_from_dictionary(std::istream& is);
     int _symbols;
     int _min_frequency;
     bool _dict_input;
     bool _total_symbols;
     std::unordered_map<std::string, int> _vocab;
-    std::unique_ptr<const Tokenizer> _default_tokenizer;
   };
 
 }

--- a/include/onmt/SPMLearner.h
+++ b/include/onmt/SPMLearner.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <string>
 #include <fstream>
 #include <memory>
 #include <unordered_map>
@@ -30,12 +29,12 @@ namespace onmt
 
     void set_input_filename(const std::string& filename);
 
-    void ingest(const std::string& text, const Tokenizer* tokenizer = nullptr) override;
-    void ingest(std::istream& is, const Tokenizer* tokenizer = 0) override;
     void learn(std::ostream& os, const char* description = 0, bool verbose = false) override;
     void learn(const std::string& model_path,
                const char* description = 0,
                bool verbose = false) override;
+  protected:
+    void ingest_token(const std::string& token) override;
   private:
     std::string _args;
     std::string _input_filename;

--- a/include/onmt/SubwordLearner.h
+++ b/include/onmt/SubwordLearner.h
@@ -1,28 +1,30 @@
 #pragma once
 
+#include <memory>
 #include <string>
-#include <vector>
 #include <iostream>
 
 #include "onmt/opennmttokenizer_export.h"
+#include "onmt/Tokenizer.h"
 
 namespace onmt
 {
-  class Tokenizer;
 
   class OPENNMTTOKENIZER_EXPORT SubwordLearner
   {
   public:
-    SubwordLearner(bool verbose);
+    SubwordLearner(bool verbose, const Tokenizer* default_tokenizer = nullptr);
     virtual ~SubwordLearner() = default;
     virtual void ingest(const std::string& text, const Tokenizer* tokenizer = nullptr);
-    virtual void ingest(std::istream& in, const Tokenizer* tokenizer = nullptr) = 0;
+    virtual void ingest(std::istream& in, const Tokenizer* tokenizer = nullptr);
     virtual void learn(std::ostream& out, const char* description = nullptr, bool verbose = false) = 0;
     virtual void learn(const std::string& model_path,
                        const char* description = nullptr,
                        bool verbose = false);
   protected:
+    virtual void ingest_token(const std::string& token) = 0;
     bool _verbose;
+    std::unique_ptr<const Tokenizer> _default_tokenizer;
   };
 
 }

--- a/src/SPMLearner.cc
+++ b/src/SPMLearner.cc
@@ -1,11 +1,6 @@
 #include "onmt/SPMLearner.h"
 
-#include <cstdio>
-#include <iostream>
-
 #include <sentencepiece_trainer.h>
-
-#include "onmt/Tokenizer.h"
 
 namespace onmt
 {
@@ -63,36 +58,10 @@ namespace onmt
       _input_stream.reset(new std::ofstream(_input_filename));
   }
 
-  void SPMLearner::ingest(const std::string& text, const Tokenizer* tokenizer)
+  void SPMLearner::ingest_token(const std::string& token)
   {
     init_input_stream();
-
-    if (!tokenizer)
-      *_input_stream << text;
-    else
-    {
-      std::vector<AnnotatedToken> tokens;
-      tokenizer->tokenize(text, tokens);
-      for (const auto& token : tokens)
-      {
-        if (!Tokenizer::is_placeholder(token.str()))
-          *_input_stream << token.str() << std::endl;
-      }
-    }
-  }
-
-  void SPMLearner::ingest(std::istream& is, const Tokenizer* tokenizer)
-  {
-    init_input_stream();
-
-    if (!tokenizer)
-      *_input_stream << is.rdbuf();
-    else
-    {
-      std::string line;
-      while (std::getline(is, line))
-        ingest(line, tokenizer);
-    }
+    *_input_stream << token << std::endl;
   }
 
   void SPMLearner::learn(std::ostream& os, const char* description, bool verbose)

--- a/src/SubwordLearner.cc
+++ b/src/SubwordLearner.cc
@@ -7,15 +7,33 @@
 namespace onmt
 {
 
-  SubwordLearner::SubwordLearner(bool verbose)
+  SubwordLearner::SubwordLearner(bool verbose, const Tokenizer* default_tokenizer)
     : _verbose(verbose)
+    , _default_tokenizer(default_tokenizer
+                         ? default_tokenizer
+                         : new Tokenizer(Tokenizer::Mode::None, Tokenizer::Flags::NoSubstitution))
   {
   }
 
   void SubwordLearner::ingest(const std::string& text, const Tokenizer* tokenizer)
   {
-    std::istringstream in(text);
-    ingest(in, tokenizer);
+    if (!tokenizer)
+      tokenizer = _default_tokenizer.get();
+
+    std::vector<AnnotatedToken> tokens;
+    tokenizer->tokenize(text, tokens);
+    for (const auto& token : tokens)
+    {
+      if (!Tokenizer::is_placeholder(token.str()))
+        ingest_token(token.str());
+    }
+  }
+
+  void SubwordLearner::ingest(std::istream& is, const Tokenizer* tokenizer)
+  {
+    std::string line;
+    while (std::getline(is, line))
+      ingest(line, tokenizer);
   }
 
   void SubwordLearner::learn(const std::string& model_path, const char* description, bool verbose)


### PR DESCRIPTION
When using `SentencePieceLearner` without a tokenizer, the input text was just forwarded to an internal training file. However, for good integration in the OpenNMT tokenizer, we always need to ignore placeholders that could be present in the input text.