### PR TITLE
Apply case_feature before subword encoding

### DIFF
--- a/src/Tokenizer.cc
+++ b/src/Tokenizer.cc
@@ -786,12 +786,10 @@ namespace onmt
         annotated_tokens.emplace_back(std::move(token));
     }
 
-    if (_case_markup)
+    if (_case_markup || _case_feature)
       annotate_case(annotated_tokens);
     if (_subword_encoder)
       annotated_tokens = encode_subword(annotated_tokens);
-    if (_case_feature)
-      annotate_case(annotated_tokens);
   }
 
   void Tokenizer::finalize_tokens(std::vector<AnnotatedToken>& annotated_tokens,


### PR DESCRIPTION
When using a tokenizer with `case_feature` during subword learning, the model will be trained on lowercase data. The same should be done when using the model.