### PR TITLE
Add public API to directly feed tokens to the subword learner

### DIFF
--- a/bindings/python/Python.cc
+++ b/bindings/python/Python.cc
@@ -268,6 +268,11 @@ public:
     _learner->ingest(text, _tokenizer.get());
   }
 
+  void ingest_token(const std::string& token)
+  {
+    _learner->ingest_token(token);
+  }
+
   TokenizerWrapper learn(const std::string& model_path, bool verbose)
   {
     {
@@ -423,6 +428,7 @@ PYBIND11_MODULE(pyonmttok, m)
          py::arg("total_symbols")=false)
     .def("ingest", &BPELearnerWrapper::ingest, py::arg("text"))
     .def("ingest_file", &BPELearnerWrapper::ingest_file, py::arg("path"))
+    .def("ingest_token", &BPELearnerWrapper::ingest_token, py::arg("token"))
     .def("learn", &BPELearnerWrapper::learn,
          py::arg("model_path"), py::arg("verbose")=false)
     ;
@@ -433,6 +439,7 @@ PYBIND11_MODULE(pyonmttok, m)
          py::arg("keep_vocab")=false)
     .def("ingest", &SentencePieceLearnerWrapper::ingest, py::arg("text"))
     .def("ingest_file", &SentencePieceLearnerWrapper::ingest_file, py::arg("path"))
+    .def("ingest_token", &SentencePieceLearnerWrapper::ingest_token, py::arg("token"))
     .def("learn", &SentencePieceLearnerWrapper::learn,
          py::arg("model_path"), py::arg("verbose")=false)
     ;

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -70,11 +70,11 @@ learner = pyonmttok.SentencePieceLearner(vocab_size=32000, character_coverage=0.
 **2\. Feed some raw data:**
 
 ```python
-# Feed sentence by sentence:
+# Feed detokenized sentences:
 learner.ingest("Hello world!")
 learner.ingest("How are you?")
 
-# or feed text files:
+# or detokenized text files:
 learner.ingest_file("/data/train1.en")
 learner.ingest_file("/data/train2.en")
 ```
@@ -107,6 +107,7 @@ learner = pyonmttok.SentencePieceLearner(
 
 learner.ingest(text: str)
 learner.ingest_file(path: str)
+learner.ingest_token(token: str)  # Low-level token-based function.
 
 tokenizer = learner.learn(model_path: str, verbose=False)
 ```

--- a/bindings/python/test/test.py
+++ b/bindings/python/test/test.py
@@ -130,6 +130,15 @@ def test_bpe_learner(tmpdir):
     tokens, _ = tokenizer.tokenize("hello")
     assert tokens == ["h￭", "ell￭", "o"]
 
+def test_bpe_learner_tokens(tmpdir):
+    learner = pyonmttok.BPELearner(symbols=2, min_frequency=1)
+    learner.ingest_token("hello")
+    learner.ingest_token("world")
+    model_path = str(tmpdir.join("bpe.model"))
+    learner.learn(model_path)
+    with open(model_path) as model:
+        assert model.read() == "#version: 0.2\ne l\nel l\n"
+
 @pytest.mark.parametrize("keep_vocab", [False, True])
 def test_sp_learner(tmpdir, keep_vocab):
     learner = pyonmttok.SentencePieceLearner(

--- a/include/onmt/BPELearner.h
+++ b/include/onmt/BPELearner.h
@@ -15,7 +15,7 @@ namespace onmt
     void ingest(std::istream& is, const Tokenizer* tokenizer = nullptr) override;
     void learn(std::ostream& os, const char* description = 0, bool verbose = false) override;
   protected:
-    void ingest_token_impl(const std::string& token) final override;
+    void ingest_token_impl(const std::string& token) final;
   private:
     void load_from_dictionary(std::istream& is);
     int _symbols;

--- a/include/onmt/BPELearner.h
+++ b/include/onmt/BPELearner.h
@@ -15,7 +15,7 @@ namespace onmt
     void ingest(std::istream& is, const Tokenizer* tokenizer = nullptr) override;
     void learn(std::ostream& os, const char* description = 0, bool verbose = false) override;
   protected:
-    void ingest_token(const std::string& token) override;
+    void ingest_token_impl(const std::string& token) final override;
   private:
     void load_from_dictionary(std::istream& is);
     int _symbols;

--- a/include/onmt/SPMLearner.h
+++ b/include/onmt/SPMLearner.h
@@ -34,7 +34,7 @@ namespace onmt
                const char* description = 0,
                bool verbose = false) override;
   protected:
-    void ingest_token_impl(const std::string& token) final override;
+    void ingest_token_impl(const std::string& token) final;
   private:
     std::string _args;
     std::string _input_filename;

--- a/include/onmt/SPMLearner.h
+++ b/include/onmt/SPMLearner.h
@@ -34,7 +34,7 @@ namespace onmt
                const char* description = 0,
                bool verbose = false) override;
   protected:
-    void ingest_token(const std::string& token) override;
+    void ingest_token_impl(const std::string& token) final override;
   private:
     std::string _args;
     std::string _input_filename;

--- a/include/onmt/SubwordLearner.h
+++ b/include/onmt/SubwordLearner.h
@@ -15,6 +15,7 @@ namespace onmt
   public:
     SubwordLearner(bool verbose, const Tokenizer* default_tokenizer = nullptr);
     virtual ~SubwordLearner() = default;
+    virtual void ingest_token(const std::string& token);
     virtual void ingest(const std::string& text, const Tokenizer* tokenizer = nullptr);
     virtual void ingest(std::istream& in, const Tokenizer* tokenizer = nullptr);
     virtual void learn(std::ostream& out, const char* description = nullptr, bool verbose = false) = 0;
@@ -22,7 +23,7 @@ namespace onmt
                        const char* description = nullptr,
                        bool verbose = false);
   protected:
-    virtual void ingest_token(const std::string& token) = 0;
+    virtual void ingest_token_impl(const std::string& token) = 0;
     bool _verbose;
     std::unique_ptr<const Tokenizer> _default_tokenizer;
   };

--- a/src/BPELearner.cc
+++ b/src/BPELearner.cc
@@ -51,7 +51,7 @@ namespace onmt
     }
   }
 
-  void BPELearner::ingest_token(const std::string& token)
+  void BPELearner::ingest_token_impl(const std::string& token)
   {
     _vocab[token]++;
   }

--- a/src/SPMLearner.cc
+++ b/src/SPMLearner.cc
@@ -52,7 +52,7 @@ namespace onmt
     _input_filename = filename;
   }
 
-  void SPMLearner::ingest_token(const std::string& token)
+  void SPMLearner::ingest_token_impl(const std::string& token)
   {
     if (!_input_stream)
       _input_stream.reset(new std::ofstream(_input_filename));

--- a/src/SubwordLearner.cc
+++ b/src/SubwordLearner.cc
@@ -15,6 +15,12 @@ namespace onmt
   {
   }
 
+  void SubwordLearner::ingest_token(const std::string& token)
+  {
+    if (!Tokenizer::is_placeholder(token))
+      ingest_token_impl(token);
+  }
+
   void SubwordLearner::ingest(const std::string& text, const Tokenizer* tokenizer)
   {
     if (!tokenizer)
@@ -23,10 +29,7 @@ namespace onmt
     std::vector<AnnotatedToken> tokens;
     tokenizer->tokenize(text, tokens);
     for (const auto& token : tokens)
-    {
-      if (!Tokenizer::is_placeholder(token.str()))
-        ingest_token(token.str());
-    }
+      ingest_token(token.str());
   }
 
   void SubwordLearner::ingest(std::istream& is, const Tokenizer* tokenizer)


### PR DESCRIPTION
This is useful when tokenizing the data outside the learner.