### PR TITLE
Take ownership of external subword encoder object by default

### DIFF
--- a/include/onmt/Tokenizer.h
+++ b/include/onmt/Tokenizer.h
@@ -62,6 +62,8 @@ namespace onmt
               int bpe_vocab_threshold = 50);
 
     // External subword encoder constructor.
+    // Note: the tokenizer takes ownership of the subword_encoder pointer unless
+    // the CacheModel flag is set.
     Tokenizer(Mode mode,
               const SubwordEncoder* subword_encoder,
               int flags = Flags::None,

--- a/src/Tokenizer.cc
+++ b/src/Tokenizer.cc
@@ -214,7 +214,6 @@ namespace onmt
     , _joiner(joiner)
   {
     read_flags(flags);
-    _cache_model = true;
 #ifdef WITH_SP
     if (dynamic_cast<const SentencePiece*>(subword_encoder) != nullptr
         && _mode == Mode::None && !_joiner_annotate && !_spacer_annotate)

--- a/test/test.cc
+++ b/test/test.cc
@@ -650,7 +650,7 @@ TEST(TokenizerTest, SentencePiece) {
 
 TEST(TokenizerTest, SentencePieceObject) {
   SentencePiece sp(get_data("sp-models/sp.model"));
-  Tokenizer tokenizer(Tokenizer::Mode::None, &sp);
+  Tokenizer tokenizer(Tokenizer::Mode::None, &sp, Tokenizer::Flags::CacheModel);
   test_tok_and_detok(tokenizer,
                      "The two shows, called Desire and Secrets, will be one-hour prime-time shows.",
                      "The ▁two ▁shows , ▁called ▁De si re ▁and ▁S e c re t s , ▁will ▁be ▁one - hour ▁prime - time ▁shows .");


### PR DESCRIPTION
Fixes #130.