### PR TITLE
Optimizations for BPE learning

### DIFF
--- a/src/BPELearner.cc
+++ b/src/BPELearner.cc
@@ -93,8 +93,8 @@ namespace onmt
 
     for(auto &change: changed) {
       int j = change._j;
-      sequence word = change._new_word;
-      sequence old_word = change._word;
+      const sequence& word = change._new_word;
+      const sequence& old_word = change._word;
       int freq = change._freq;
 
       // find all instances of pair, and update frequency/indices around it
@@ -177,7 +177,7 @@ namespace onmt
   }
 
   static std::vector<change> replace_pair(
-            const bigram pair,
+            const bigram& pair,
             std::vector<std::pair<int, sequence > > &sorted_vocab,
             std::map<bigram, std::map<int, int> > &indices) {
     /* Replace all occurrences of a symbol pair ('A', 'B') with a new symbol 'AB' */
@@ -217,7 +217,7 @@ namespace onmt
     for(auto it = stats.begin(); it != stats.end();) {
       auto itnext = it;
       itnext++;
-      bigram item = it->first;
+      const bigram& item = it->first;
       int freq = it->second;
       if (freq < threshold) {
         stats.erase(it);

--- a/src/BPELearner.cc
+++ b/src/BPELearner.cc
@@ -185,22 +185,16 @@ namespace onmt
                       std::unordered_map<const bigram*, int>& stats,
                       std::unordered_map<const bigram*, std::unordered_map<int, int>>& indices) {
     /* Count frequency of all symbol pairs, and create index */
-    
-    std::unordered_set<std::string> uniq_char_internal;
-    std::unordered_set<std::string> uniq_char_final;
     int max = 0;
     for(size_t i = 0; i < sorted_vocab.size(); i++) {
-      int freq = sorted_vocab[i].first;
+      const int freq = sorted_vocab[i].first;
       const sequence &word = sorted_vocab[i].second;
       for(size_t j = 1; j < word.size(); j++) {
         const bigram* pair = get_bigram(collection, word[j-1], word[j]);
         stats[pair] += freq;
-        if (stats[pair] > max)
-          max = stats[pair];
+        max = std::max(stats[pair], max);
         indices[pair][i] += 1;
-        uniq_char_internal.insert(word[j-1]);
       }
-      uniq_char_final.insert(word.back());
     }
   }
 

--- a/src/BPELearner.cc
+++ b/src/BPELearner.cc
@@ -96,8 +96,8 @@ namespace onmt
   static void update_pair_statistics(bigram_collection& collection,
                                      const bigram* pair,
                                      std::vector<change> &changed,
-                                     std::map<const bigram*, int> &stats,
-                                     std::map<const bigram*, std::map<int, int> > &indices) {
+                                     std::unordered_map<const bigram*, int> &stats,
+                                     std::unordered_map<const bigram*, std::map<int, int> > &indices) {
     /* Minimally update the indices and frequency of symbol pairs
 
     if we merge a pair of symbols, only pairs that overlap with occurrences
@@ -175,8 +175,8 @@ namespace onmt
 
   static void get_pair_statistics(bigram_collection& collection,
                                   const std::vector<std::pair<int, sequence > > &sorted_vocab,
-                                  std::map<const bigram*, int> &stats,
-                                  std::map<const bigram*, std::map<int, int> > &indices) {
+                                  std::unordered_map<const bigram*, int> &stats,
+                                  std::unordered_map<const bigram*, std::map<int, int> > &indices) {
     /* Count frequency of all symbol pairs, and create index */
     
     std::set<std::string> uniq_char_internal;
@@ -200,7 +200,7 @@ namespace onmt
   static std::vector<change> replace_pair(
             const bigram* pair,
             std::vector<std::pair<int, sequence > > &sorted_vocab,
-            std::map<const bigram*, std::map<int, int> > &indices) {
+            std::unordered_map<const bigram*, std::map<int, int> > &indices) {
     /* Replace all occurrences of a symbol pair ('A', 'B') with a new symbol 'AB' */
     const std::string &A = pair->first;
     const std::string &B = pair->second;
@@ -226,8 +226,8 @@ namespace onmt
     return changes;
   }
 
-  static void prune_stats(std::map<const bigram*, int> &stats,
-                          std::map<const bigram*, int> &big_stats,
+  static void prune_stats(std::unordered_map<const bigram*, int> &stats,
+                          std::unordered_map<const bigram*, int> &big_stats,
                           float threshold) {
     /* Prune statistics dict for efficiency of max()
 
@@ -276,7 +276,7 @@ namespace onmt
   }
 
   static std::pair<const bigram*, int>
-  get_most_frequent(const std::map<const bigram*, int>& stats) {
+  get_most_frequent(const std::unordered_map<const bigram*, int>& stats) {
     static const bigram empty;
 
     const bigram* most_frequent = &empty;
@@ -306,11 +306,11 @@ namespace onmt
 
     std::vector<std::pair<int, sequence>> sorted_vocab = get_inv_char_frequency(_vocab);
     bigram_collection collection;
-    std::map<const bigram*, int> stats;
-    std::map<const bigram*, std::map<int, int> > indices;
+    std::unordered_map<const bigram*, int> stats;
+    std::unordered_map<const bigram*, std::map<int, int> > indices;
     get_pair_statistics(collection, sorted_vocab, stats, indices);
 
-    std::map<const bigram*, int> big_stats(stats);
+    std::unordered_map<const bigram*, int> big_stats(stats);
 
     if (_total_symbols) {
       std::set<std::string> uniq_char_internal;

--- a/src/BPELearner.cc
+++ b/src/BPELearner.cc
@@ -306,17 +306,14 @@ namespace onmt
       _symbols -= uniq_char_internal.size() + uniq_char_final.size();
     }
 
-    std::set<std::pair<int, bigram > > invstats;
-    for(auto it = stats.begin(); it != stats.end(); it++)
-      invstats.insert(std::make_pair(-it->second, it->first));
-
+    const bool empty_stats = stats.empty();
     const int max = get_most_frequent(stats).second;
 
     float threshold = max / 10.;
     for(int i = 0; i < _symbols; i++) {
       const bigram* most_frequent = get_most_frequent(stats).first;
 
-      if (invstats.size() == 0 || (i && stats[*most_frequent] < threshold)) {
+      if (empty_stats || (i && stats[*most_frequent] < threshold)) {
         prune_stats(stats, big_stats, threshold);
         stats = big_stats;
         most_frequent = get_most_frequent(stats).first;

--- a/src/BPELearner.cc
+++ b/src/BPELearner.cc
@@ -179,8 +179,8 @@ namespace onmt
                                   std::unordered_map<const bigram*, std::map<int, int> > &indices) {
     /* Count frequency of all symbol pairs, and create index */
     
-    std::set<std::string> uniq_char_internal;
-    std::set<std::string> uniq_char_final;
+    std::unordered_set<std::string> uniq_char_internal;
+    std::unordered_set<std::string> uniq_char_final;
     int max = 0;
     for(size_t i = 0; i < sorted_vocab.size(); i++) {
       int freq = sorted_vocab[i].first;
@@ -309,8 +309,8 @@ namespace onmt
     std::unordered_map<const bigram*, int> big_stats(stats);
 
     if (_total_symbols) {
-      std::set<std::string> uniq_char_internal;
-      std::set<std::string> uniq_char_final;
+      std::unordered_set<std::string> uniq_char_internal;
+      std::unordered_set<std::string> uniq_char_final;
       for(size_t i = 0; i < sorted_vocab.size(); i++) {
         const sequence &word = sorted_vocab[i].second;
         for(size_t j = 1; j < word.size(); j++) {

--- a/src/BPELearner.cc
+++ b/src/BPELearner.cc
@@ -14,7 +14,6 @@ The code is converted from bpe_learn.py (https://github.com/rsennrich/subword-nm
 
 #include <algorithm>
 #include <limits>
-#include <map>
 #include <unordered_set>
 
 #include "onmt/unicode/Unicode.h"
@@ -93,11 +92,12 @@ namespace onmt
     return &(*collection.emplace(a, b).first);
   }
 
-  static void update_pair_statistics(bigram_collection& collection,
-                                     const bigram* pair,
-                                     const std::vector<change> &changed,
-                                     std::unordered_map<const bigram*, int> &stats,
-                                     std::unordered_map<const bigram*, std::map<int, int> > &indices) {
+  static void
+  update_pair_statistics(bigram_collection& collection,
+                         const bigram* pair,
+                         const std::vector<change>& changed,
+                         std::unordered_map<const bigram*, int>& stats,
+                         std::unordered_map<const bigram*, std::unordered_map<int, int>>& indices) {
     /* Minimally update the indices and frequency of symbol pairs
 
     if we merge a pair of symbols, only pairs that overlap with occurrences
@@ -173,10 +173,11 @@ namespace onmt
     }
   }
 
-  static void get_pair_statistics(bigram_collection& collection,
-                                  const std::vector<std::pair<int, sequence > > &sorted_vocab,
-                                  std::unordered_map<const bigram*, int> &stats,
-                                  std::unordered_map<const bigram*, std::map<int, int> > &indices) {
+  static void
+  get_pair_statistics(bigram_collection& collection,
+                      const std::vector<std::pair<int, sequence>>& sorted_vocab,
+                      std::unordered_map<const bigram*, int>& stats,
+                      std::unordered_map<const bigram*, std::unordered_map<int, int>>& indices) {
     /* Count frequency of all symbol pairs, and create index */
     
     std::unordered_set<std::string> uniq_char_internal;
@@ -197,10 +198,10 @@ namespace onmt
     }
   }
 
-  static std::vector<change> replace_pair(
-            const bigram* pair,
-            std::vector<std::pair<int, sequence > > &sorted_vocab,
-            std::unordered_map<const bigram*, std::map<int, int> > &indices) {
+  static std::vector<change>
+  replace_pair(const bigram* pair,
+               std::vector<std::pair<int, sequence>>& sorted_vocab,
+               std::unordered_map<const bigram*, std::unordered_map<int, int>>& indices) {
     /* Replace all occurrences of a symbol pair ('A', 'B') with a new symbol 'AB' */
     const std::string &A = pair->first;
     const std::string &B = pair->second;
@@ -227,8 +228,8 @@ namespace onmt
     return changes;
   }
 
-  static void prune_stats(std::unordered_map<const bigram*, int> &stats,
-                          std::unordered_map<const bigram*, int> &big_stats,
+  static void prune_stats(std::unordered_map<const bigram*, int>& stats,
+                          std::unordered_map<const bigram*, int>& big_stats,
                           float threshold) {
     /* Prune statistics dict for efficiency of max()
 
@@ -304,7 +305,7 @@ namespace onmt
     std::vector<std::pair<int, sequence>> sorted_vocab = get_inv_char_frequency(_vocab);
     bigram_collection collection;
     std::unordered_map<const bigram*, int> stats;
-    std::unordered_map<const bigram*, std::map<int, int> > indices;
+    std::unordered_map<const bigram*, std::unordered_map<int, int>> indices;
     get_pair_statistics(collection, sorted_vocab, stats, indices);
 
     std::unordered_map<const bigram*, int> big_stats(stats);

--- a/src/BPELearner.cc
+++ b/src/BPELearner.cc
@@ -236,20 +236,20 @@ namespace onmt
     (until we the most frequent pair is less frequent than a pair we previously pruned)
     big_stats keeps full statistics for when we need to access pruned items
     */
-    for(auto it = stats.begin(); it != stats.end();) {
-      auto itnext = it;
-      itnext++;
-      const bigram* item = it->first;
-      int freq = it->second;
+    std::unordered_map<const bigram*, int> pruned_stats;
+    for (auto& stat : stats) {
+      const int freq = stat.second;
       if (freq < threshold) {
-        stats.erase(it);
+        const bigram* item = stat.first;
         if (freq < 0)
           big_stats[item] += freq;
         else
           big_stats[item] = freq;
+      } else {
+        pruned_stats.emplace(std::move(stat));
       }
-      it = itnext;
     }
+    stats = std::move(pruned_stats);
   }
 
   static std::vector<std::pair<int, sequence>>

--- a/src/BPELearner.cc
+++ b/src/BPELearner.cc
@@ -204,13 +204,14 @@ namespace onmt
     /* Replace all occurrences of a symbol pair ('A', 'B') with a new symbol 'AB' */
     const std::string &A = pair->first;
     const std::string &B = pair->second;
-    
+
+    const auto& pair_indices = indices[pair];
     std::vector<change> changes;
-    for(auto it = indices[pair].begin(); 
-        it != indices[pair].end(); it++) {
-      if (it->second < 1)
+    changes.reserve(pair_indices.size());
+    for (const auto& index : pair_indices) {
+      if (index.second < 1)
         continue;
-      int j = it->first;
+      const int j = index.first;
       sequence &word = sorted_vocab[j].second;
       int freq = sorted_vocab[j].first;
 

--- a/src/BPELearner.cc
+++ b/src/BPELearner.cc
@@ -111,7 +111,7 @@ namespace onmt
     */
 
     stats[pair] = 0;
-    indices[pair].clear();
+    indices[pair] = std::unordered_map<int, int>();
     const std::string &first = pair->first;
     const std::string &second = pair->second;
 

--- a/src/BPELearner.cc
+++ b/src/BPELearner.cc
@@ -14,7 +14,6 @@ The code is converted from bpe_learn.py (https://github.com/rsennrich/subword-nm
 
 #include <algorithm>
 #include <limits>
-#include <list>
 #include <map>
 
 #include "onmt/unicode/Unicode.h"
@@ -76,7 +75,7 @@ namespace onmt
   };
 
   static void update_pair_statistics(const bigram &pair,
-                                     std::list<change> &changed,
+                                     std::vector<change> &changed,
                                      std::map<bigram, int> &stats,
                                      std::map<bigram, std::map<int, int> > &indices) {
     /* Minimally update the indices and frequency of symbol pairs
@@ -177,7 +176,7 @@ namespace onmt
     }
   }
 
-  static std::list<change> replace_pair(
+  static std::vector<change> replace_pair(
             const bigram pair,
             std::vector<std::pair<int, sequence > > &sorted_vocab,
             std::map<bigram, std::map<int, int> > &indices) {
@@ -185,7 +184,7 @@ namespace onmt
     const std::string &A = pair.first;
     const std::string &B = pair.second;
     
-    std::list<change> changes;
+    std::vector<change> changes;
     for(auto it = indices[pair].begin(); 
         it != indices[pair].end(); it++) {
       if (it->second < 1)
@@ -200,7 +199,7 @@ namespace onmt
           word[h] += B;
           word.erase(word.begin()+h+1);
         }
-      changes.push_back(change(j, word, wordcopy, freq));
+      changes.emplace_back(j, word, wordcopy, freq);
     }
 
     return changes;
@@ -339,7 +338,7 @@ namespace onmt
       
       os << most_frequent.first << " " << most_frequent.second << "\n";
 
-      std::list<change> changes = replace_pair(most_frequent, sorted_vocab, indices);
+      std::vector<change> changes = replace_pair(most_frequent, sorted_vocab, indices);
       update_pair_statistics(most_frequent, changes, stats, indices);
       stats[most_frequent] = 0;
       if (i % 100 == 0)

--- a/src/BPELearner.cc
+++ b/src/BPELearner.cc
@@ -95,7 +95,7 @@ namespace onmt
 
   static void update_pair_statistics(bigram_collection& collection,
                                      const bigram* pair,
-                                     std::vector<change> &changed,
+                                     const std::vector<change> &changed,
                                      std::unordered_map<const bigram*, int> &stats,
                                      std::unordered_map<const bigram*, std::map<int, int> > &indices) {
     /* Minimally update the indices and frequency of symbol pairs
@@ -111,11 +111,11 @@ namespace onmt
 
     std::string new_pair = first + second;
 
-    for(auto &change: changed) {
-      int j = change._j;
+    for(const auto& change : changed) {
+      const int j = change._j;
       const sequence& word = change._new_word;
       const sequence& old_word = change._word;
-      int freq = change._freq;
+      const int freq = change._freq;
 
       // find all instances of pair, and update frequency/indices around it
       size_t i = 0;
@@ -355,7 +355,7 @@ namespace onmt
       
       os << most_frequent->first << " " << most_frequent->second << "\n";
 
-      std::vector<change> changes = replace_pair(most_frequent, sorted_vocab, indices);
+      const std::vector<change> changes = replace_pair(most_frequent, sorted_vocab, indices);
       update_pair_statistics(collection, most_frequent, changes, stats, indices);
       stats[most_frequent] = 0;
       if (i % 100 == 0)


### PR DESCRIPTION
Apply some performance and memory optimizations:

* Store bigrams in a shared container instead of duplicating and copying them
* Use unordered version of containers
* Remove some unused structures (e.g. `invstats`)
* Cleanup code: avoid copy by value, reserve vectors, avoid duplicated map lookup, etc.

The BPE model in output is unchanged.