### PR TITLE
make Boost (program_options) required for CLI

### DIFF
--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Boost COMPONENTS program_options)
+find_package(Boost REQUIRED COMPONENTS program_options)
 
 include_directories(
   ${Boost_INCLUDE_DIRS}


### PR DESCRIPTION
Without it being required, if it is not found, there will be no error from cmake, yet the project will not compile.