### PR TITLE
set GoogleTest location based on current directory

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,7 @@ enable_testing()
 
 set(BUILD_GMOCK OFF)
 set(INSTALL_GTEST OFF)
-add_subdirectory(${CMAKE_SOURCE_DIR}/third_party/googletest ${CMAKE_CURRENT_BINARY_DIR}/googletest)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../third_party/googletest ${CMAKE_CURRENT_BINARY_DIR}/googletest)
 
 add_executable(onmt_tokenizer_test test.cc)
 target_link_libraries(onmt_tokenizer_test


### PR DESCRIPTION
By setting the googletest path based on current source directory (Tokenizer/test) and not setting it based on the top level source directory, Tokenizer will build as a submodule (e.g., as in CTranslate). Otherwise it looks for a non-existent directory (e.g., CTranslate/third_party/googletest).