### PR TITLE
Ignore empty tokens during detokenization

### DIFF
--- a/src/Tokenizer.cc
+++ b/src/Tokenizer.cc
@@ -450,6 +450,9 @@ namespace onmt
 
     for (size_t i = 0; i < words.size(); ++i)
     {
+      if (words[i].empty())
+        continue;
+
       size_t features_offset = 0;
       if (_case_feature)
       {

--- a/test/test.cc
+++ b/test/test.cc
@@ -803,6 +803,13 @@ TEST(TokenizerTest, AnnotatedTokenInterface)
   EXPECT_EQ(tokenizer.detokenize(tokens), text);
 }
 
+TEST(TokenizerTest, DetokenizeEmptyToken)
+{
+  Tokenizer tokenizer(Tokenizer::Mode::Aggressive, Tokenizer::Flags::JoinerAnnotate);
+  const std::vector<std::string> tokens = { "a", "", "b" };
+  EXPECT_EQ(tokenizer.detokenize(tokens), "a b");
+}
+
 int main(int argc, char *argv[]) {
   testing::InitGoogleTest(&argc, argv);
   assert(argc == 2);


### PR DESCRIPTION
This prevents unwanted double spaces in the detokenized output.