### PR TITLE
Cleanup Token structure

### DIFF
--- a/bindings/python/Python.cc
+++ b/bindings/python/Python.cc
@@ -176,9 +176,9 @@ public:
     _tokenizer.reset(tokenizer);
   }
 
-  py::object tokenize(const std::string& text, const bool as_tokens) const
+  py::object tokenize(const std::string& text, const bool as_token_objects) const
   {
-    if (as_tokens)
+    if (as_token_objects)
     {
       std::vector<onmt::Token> tokens;
       _tokenizer->tokenize(text, tokens);
@@ -497,7 +497,7 @@ PYBIND11_MODULE(pyonmttok, m)
          py::arg("segment_alphabet")=py::list())
     .def("tokenize", &TokenizerWrapper::tokenize,
          py::arg("text"),
-         py::arg("as_tokens")=false)
+         py::arg("as_token_objects")=false)
     .def("serialize_tokens", &TokenizerWrapper::serialize_tokens,
          py::arg("tokens"))
     .def("deserialize_tokens", &TokenizerWrapper::deserialize_tokens,

--- a/bindings/python/Python.cc
+++ b/bindings/python/Python.cc
@@ -447,17 +447,23 @@ PYBIND11_MODULE(pyonmttok, m)
     .value("NONE", onmt::CaseModifier::Type::None)
     .export_values();
 
+  py::enum_<onmt::TokenType>(m, "TokenType")
+    .value("WORD", onmt::TokenType::Word)
+    .value("LEADING_SUBWORD", onmt::TokenType::LeadingSubword)
+    .value("TRAILING_SUBWORD", onmt::TokenType::TrailingSubword)
+    .export_values();
+
   py::class_<onmt::Token>(m, "Token")
     .def(py::init<>())
     .def(py::init<std::string>())
     .def_readwrite("surface", &onmt::Token::surface)
+    .def_readwrite("type", &onmt::Token::type)
     .def_readwrite("join_left", &onmt::Token::join_left)
     .def_readwrite("join_right", &onmt::Token::join_right)
     .def_readwrite("spacer", &onmt::Token::spacer)
     .def_readwrite("preserve", &onmt::Token::preserve)
     .def_readwrite("features", &onmt::Token::features)
     .def_readwrite("casing", &onmt::Token::case_type)
-    .def_readwrite("subword", &onmt::Token::subword)
     .def("__eq__", &onmt::Token::operator==)
     ;
 

--- a/bindings/python/Python.cc
+++ b/bindings/python/Python.cc
@@ -2,6 +2,7 @@
 #include <memory>
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include <onmt/Tokenizer.h>
 #include <onmt/BPE.h>

--- a/bindings/python/Python.cc
+++ b/bindings/python/Python.cc
@@ -457,8 +457,7 @@ PYBIND11_MODULE(pyonmttok, m)
     .def_readwrite("preserve", &onmt::Token::preserve)
     .def_readwrite("features", &onmt::Token::features)
     .def_readwrite("casing", &onmt::Token::case_type)
-    .def_readwrite("begin_case_region", &onmt::Token::begin_case_region)
-    .def_readwrite("end_case_region", &onmt::Token::end_case_region)
+    .def_readwrite("subword", &onmt::Token::subword)
     .def("__eq__", &onmt::Token::operator==)
     ;
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -52,7 +52,7 @@ See the [documentation](../../docs/options.md) for a description of each tokeniz
 
 ```python
 # By default, tokenize returns the tokens and features.
-tokenizer.tokenize(text: str) -> Tuple[List[str], List[List[str]]
+tokenizer.tokenize(text: str) -> Tuple[List[str], List[List[str]]]
 
 # The as_token_objects flag can alternatively return Token objects (see below).
 tokenizer.tokenize(text: str, as_token_objects=True) -> List[pyonmttok.Token]
@@ -195,8 +195,11 @@ The `Tokenizer` instances provide methods to serialize or deserialize `Token` ob
 
 ```python
 # Serialize Token objects to strings that can be saved on disk.
-tokenizer.serialize_tokens(tokens: List[pyonmttok.Token]) -> Tuple[List[str], List[List[str]]
+tokenizer.serialize_tokens(tokens: List[pyonmttok.Token]) -> Tuple[List[str], List[List[str]]]
 
 # Deserialize strings into Token objects.
-tokenizer.deserialize_tokens(tokens: list, features: list = None) -> List[pyonmttok.Token]
+tokenizer.deserialize_tokens(
+    tokens: List[str],
+    features: List[List[str]] = None
+) -> List[pyonmttok.Token]
 ```

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -149,13 +149,19 @@ The Token API allows to tokenize text into `pyonmttok.Token` objects. This API c
 The `pyonmttok.Token` class has the following attributes:
 
 * `surface`: a string, the token value
+* `type`: a `pyonmttok.TokenType` value, the type of the token
 * `join_left`: a boolean, whether the token should be joined to the token on the left or not
 * `join_right`: a boolean, whether the token should be joined to the token on the right or not
-* `spacer`: a boolean, whether the token is a spacer
 * `preserve`: a boolean, whether joiners and spacers can be attached to this token or not
 * `features`: a list of string, the features attached to the token
-* `casing`: a `pyonmttok.Casing` value, the casing of the token
-* `subword`: a boolean, whether the token is a subword
+* `spacer`: a boolean, whether the token is prefixed by a SentencePiece spacer or not (only set when using SentencePiece)
+* `casing`: a `pyonmttok.Casing` value, the casing of the token (only set when tokenizing with `case_feature` or `case_markup`)
+
+The `pyonmttok.TokenType` enumeration can take the following values:
+
+* `TokenType.WORD`
+* `TokenType.LEADING_SUBWORD`
+* `TokenType.TRAILING_SUBWORD`
 
 The `pyonmttok.Casing` enumeration can take the following values:
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -155,8 +155,7 @@ The `pyonmttok.Token` class has the following attributes:
 * `preserve`: a boolean, whether joiners and spacers can be attached to this token or not
 * `features`: a list of string, the features attached to the token
 * `casing`: a `pyonmttok.Casing` value, the casing of the token
-* `begin_case_region`: a `pyonmttok.Casing` value, the casing region that the token opens
-* `end_case_region`: a `pyonmttok.Casing` value, the casing region that the token closes
+* `subword`: a boolean, whether the token is a subword
 
 The `pyonmttok.Casing` enumeration can take the following values:
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -18,9 +18,9 @@ pip install pyonmttok
 
 ### Interface
 
-```python
-import pyonmttok
+#### Constructor
 
+```python
 tokenizer = pyonmttok.Tokenizer(
     mode: str,
     bpe_model_path: str = "",
@@ -43,24 +43,44 @@ tokenizer = pyonmttok.Tokenizer(
     segment_numbers: bool = False,
     segment_alphabet_change: bool = False,
     support_prior_joiners: bool = False,
-    segment_alphabet: list = [])
-
-# See section "Token API" below for more information about the as_tokens argument.
-tokens, features = tokenizer.tokenize(text: str, as_tokens: bool = False)
-
-text = tokenizer.detokenize(tokens: list, features: list = None)
-
-# Function that also returns a dictionary mapping a token index to a range in
-# the detokenized text. Set merge_ranges=True to merge consecutive ranges, e.g.
-# subwords of the same token in case of subword tokenization.
-text, ranges = tokenizer.detokenize_with_ranges(tokens: list, merge_ranges: bool = True)
-
-# File-based APIs
-tokenizer.tokenize_file(input_path: str, output_path: str, num_threads: int = 1)
-tokenizer.detokenize_file(input_path: str, output_path: str)
+    segment_alphabet: List[str] = [])
 ```
 
-See the [documentation](../../docs/options.md) for a description of each option.
+See the [documentation](../../docs/options.md) for a description of each tokenization option.
+
+#### Tokenization
+
+```python
+# By default, tokenize returns the tokens and features.
+tokenizer.tokenize(text: str) -> Tuple[List[str], List[List[str]]
+
+# The as_token_objects flag can alternatively return Token objects (see below).
+tokenizer.tokenize(text: str, as_token_objects=True) -> List[pyonmttok.Token]
+
+# Tokenize a file.
+tokenizer.tokenize_file(input_path: str, output_path: str, num_threads: int = 1)
+```
+
+#### Detokenization
+
+```python
+# The detokenize method converts tokens back to a string.
+tokenizer.detokenize(
+    tokens: Union[List[str], List[pyonmttok.Token]],
+    features: List[List[str]] = None
+) -> str
+
+# The detokenize_with_ranges method also returns a dictionary mapping a token
+# index to a range in the detokenized text. Set merge_ranges=True to merge
+# consecutive ranges, e.g. subwords of the same token in case of subword tokenization.
+tokenizer.detokenize_with_ranges(
+    tokens: Union[List[str], List[pyonmttok.Token]],
+    merge_ranges: bool = True
+) -> Tuple[str, Dict[int, Pair[int, int]]]
+
+# Detokenize a file.
+tokenizer.detokenize_file(input_path: str, output_path: str)
+```
 
 ## Subword learning
 
@@ -121,7 +141,7 @@ learner.ingest(text: str)
 learner.ingest_file(path: str)
 learner.ingest_token(token: str)
 
-tokenizer = learner.learn(model_path: str, verbose: bool = False)
+learner.learn(model_path: str, verbose: bool = False) -> pyonmttok.Tokenizer
 ```
 
 ## Token API
@@ -132,7 +152,7 @@ The Token API allows to tokenize text into `pyonmttok.Token` objects. This API c
 
 ```python
 >>> tokenizer = pyonmttok.Tokenizer("aggressive", joiner_annotate=True)
->>> tokens = tokenizer.tokenize("Hello World!", as_tokens=True)
+>>> tokens = tokenizer.tokenize("Hello World!", as_token_objects=True)
 >>> tokens[-1].surface
 '!'
 >>> tokenizer.serialize_tokens(tokens)[0]
@@ -157,13 +177,13 @@ The `pyonmttok.Token` class has the following attributes:
 * `spacer`: a boolean, whether the token is prefixed by a SentencePiece spacer or not (only set when using SentencePiece)
 * `casing`: a `pyonmttok.Casing` value, the casing of the token (only set when tokenizing with `case_feature` or `case_markup`)
 
-The `pyonmttok.TokenType` enumeration can take the following values:
+The `pyonmttok.TokenType` enumeration is used to identify tokens that were split by a subword tokenization. The enumeration has the following values:
 
 * `TokenType.WORD`
 * `TokenType.LEADING_SUBWORD`
 * `TokenType.TRAILING_SUBWORD`
 
-The `pyonmttok.Casing` enumeration can take the following values:
+The `pyonmttok.Casing` enumeration is used to identify the original casing of a token that was lowercased by the `case_feature` or `case_markup` tokenization options. The enumeration has the following values:
 
 * `Casing.LOWERCASE`
 * `Casing.UPPERCASE`
@@ -175,8 +195,8 @@ The `Tokenizer` instances provide methods to serialize or deserialize `Token` ob
 
 ```python
 # Serialize Token objects to strings that can be saved on disk.
-tokens, features = tokenizer.serialize_tokens(tokens: list)
+tokenizer.serialize_tokens(tokens: List[pyonmttok.Token]) -> Tuple[List[str], List[List[str]]
 
 # Deserialize strings into Token objects.
-tokens = tokenizer.deserialize_tokens(tokens: list, features: list = None)
+tokenizer.deserialize_tokens(tokens: list, features: list = None) -> List[pyonmttok.Token]
 ```

--- a/bindings/python/test/test.py
+++ b/bindings/python/test/test.py
@@ -246,3 +246,17 @@ def test_token_api_with_subword():
     tokens = tokenizer.deserialize_tokens(serialized_tokens)
     _check_subword(tokens)
     assert serialized_tokens == tokenizer.serialize_tokens(tokens)[0]
+
+def test_token_api_features():
+    tokenizer = pyonmttok.Tokenizer("space")
+    tokens = tokenizer.tokenize("a b", as_tokens=True)
+    assert tokens[0].features == []
+    assert tokens[1].features == []
+
+    tokens = tokenizer.tokenize("a￨1 b￨2", as_tokens=True)
+    assert tokens[0].features == ["1"]
+    assert tokens[1].features == ["2"]
+
+    tokens, features = tokenizer.serialize_tokens(tokens)
+    assert tokens == ["a", "b"]
+    assert features == [["1", "2"]]

--- a/bindings/python/test/test.py
+++ b/bindings/python/test/test.py
@@ -232,11 +232,11 @@ def test_token_api_with_subword():
     text = "BONJOUR MONDE"
     def _check_subword(tokens):
         assert len(tokens) == 5
-        assert not tokens[0].subword  # bon
-        assert tokens[1].subword      # j
-        assert tokens[2].subword      # our
-        assert not tokens[3].subword  # mon
-        assert tokens[4].subword      # de
+        assert tokens[0].type == pyonmttok.TokenType.LEADING_SUBWORD   # bon
+        assert tokens[1].type == pyonmttok.TokenType.TRAILING_SUBWORD  # j
+        assert tokens[2].type == pyonmttok.TokenType.TRAILING_SUBWORD  # our
+        assert tokens[3].type == pyonmttok.TokenType.LEADING_SUBWORD   # mon
+        assert tokens[4].type == pyonmttok.TokenType.TRAILING_SUBWORD  # de
 
     tokens = tokenizer.tokenize(text, as_tokens=True)
     _check_subword(tokens)

--- a/include/onmt/CaseModifier.h
+++ b/include/onmt/CaseModifier.h
@@ -1,11 +1,14 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include "onmt/opennmttokenizer_export.h"
 
 namespace onmt
 {
+
+  class Token;
 
   // TODO: this should not be a class.
   class OPENNMTTOKENIZER_EXPORT CaseModifier
@@ -37,10 +40,27 @@ namespace onmt
     };
 
     static Markup get_case_markup(const std::string& str);
+    static std::string generate_case_markup(Markup markup, Type type);
     static Type get_case_modifier_from_markup(const std::string& markup);
-    static std::string generate_case_markup(Type type);
-    static std::string generate_case_markup_begin(Type type);
-    static std::string generate_case_markup_end(Type type);
+
+    struct TokenMarkup
+    {
+      TokenMarkup(Markup prefix_, Markup suffix_, Type type_)
+        : prefix(prefix_)
+        , suffix(suffix_)
+        , type(type_)
+      {
+      }
+      Markup prefix;
+      Markup suffix;
+      Type type;
+    };
+
+    // In "soft" mode, this function tries to minimize the number of uppercase regions by possibly
+    // including case invariant characters (numbers, symbols, etc.) in uppercase regions.
+    static std::vector<TokenMarkup>
+    get_case_markups(const std::vector<Token>& tokens, const bool soft = true);
+
   };
 
 }

--- a/include/onmt/CaseModifier.h
+++ b/include/onmt/CaseModifier.h
@@ -16,11 +16,11 @@ namespace onmt
   public:
     enum class Type
     {
+      None,
       Lowercase,
       Uppercase,
       Mixed,
       Capitalized,
-      None
     };
 
     static std::pair<std::string, Type> extract_case_type(const std::string& token);
@@ -33,10 +33,10 @@ namespace onmt
 
     enum class Markup
     {
+      None,
       Modifier,
       RegionBegin,
       RegionEnd,
-      None
     };
 
     static Markup get_case_markup(const std::string& str);

--- a/include/onmt/Token.h
+++ b/include/onmt/Token.h
@@ -17,8 +17,9 @@ namespace onmt
     TrailingSubword,
   };
 
-  struct OPENNMTTOKENIZER_EXPORT Token
+  class OPENNMTTOKENIZER_EXPORT Token
   {
+  public:
     std::string surface;
     TokenType type;
     CaseModifier::Type case_type = CaseModifier::Type::None;

--- a/include/onmt/Token.h
+++ b/include/onmt/Token.h
@@ -40,14 +40,6 @@ namespace onmt
       surface += str;
     }
 
-    void clear()
-    {
-      surface.clear();
-      join_right = false;
-      join_left = false;
-      preserve = false;
-    }
-
     bool empty() const {
       return surface.empty();
     }

--- a/include/onmt/Token.h
+++ b/include/onmt/Token.h
@@ -10,15 +10,22 @@
 namespace onmt
 {
 
+  enum class TokenType
+  {
+    Word,
+    LeadingSubword,
+    TrailingSubword,
+  };
+
   struct OPENNMTTOKENIZER_EXPORT Token
   {
     std::string surface;
+    TokenType type;
     CaseModifier::Type case_type = CaseModifier::Type::None;
     bool join_left = false;
     bool join_right = false;
     bool spacer = false;
     bool preserve = false;
-    bool subword = false;
     std::vector<std::string> features;
 
     Token() = default;

--- a/include/onmt/Token.h
+++ b/include/onmt/Token.h
@@ -66,12 +66,13 @@ namespace onmt
     bool operator==(const Token& other) const
     {
       return (surface == other.surface
+              && type == other.type
+              && case_type == other.case_type
               && join_left == other.join_left
               && join_right == other.join_right
               && spacer == other.spacer
               && preserve == other.preserve
-              && features == other.features
-              && case_type == other.case_type);
+              && features == other.features);
     }
 
   };

--- a/include/onmt/Token.h
+++ b/include/onmt/Token.h
@@ -14,14 +14,12 @@ namespace onmt
   {
     std::string surface;
     CaseModifier::Type case_type = CaseModifier::Type::None;
-    CaseModifier::Type begin_case_region = CaseModifier::Type::None;
-    CaseModifier::Type end_case_region = CaseModifier::Type::None;
     bool join_left = false;
     bool join_right = false;
     bool spacer = false;
     bool preserve = false;
+    bool subword = false;
     std::vector<std::string> features;
-    size_t index = 0;
 
     Token() = default;
     Token(std::string str)
@@ -55,16 +53,6 @@ namespace onmt
       return case_type != CaseModifier::Type::None;
     }
 
-    bool begins_case_region() const
-    {
-      return begin_case_region != CaseModifier::Type::None;
-    }
-
-    bool ends_case_region() const
-    {
-      return end_case_region != CaseModifier::Type::None;
-    }
-
     void append_feature(std::string feature)
     {
       features.emplace_back(std::move(feature));
@@ -83,9 +71,7 @@ namespace onmt
               && spacer == other.spacer
               && preserve == other.preserve
               && features == other.features
-              && case_type == other.case_type
-              && begin_case_region == other.begin_case_region
-              && end_case_region == other.end_case_region);
+              && case_type == other.case_type);
     }
 
   };

--- a/include/onmt/Token.h
+++ b/include/onmt/Token.h
@@ -21,7 +21,7 @@ namespace onmt
   {
   public:
     std::string surface;
-    TokenType type;
+    TokenType type = TokenType::Word;
     CaseModifier::Type case_type = CaseModifier::Type::None;
     bool join_left = false;
     bool join_right = false;

--- a/include/onmt/Tokenizer.h
+++ b/include/onmt/Tokenizer.h
@@ -170,10 +170,17 @@ namespace onmt
                   std::vector<std::vector<std::string> >& features,
                   std::unordered_map<std::string, size_t>* alphabets) const;
     std::string detokenize(const std::vector<Token>& tokens,
-                           Ranges* ranges, bool merge_ranges = false) const;
+                           Ranges* ranges,
+                           bool merge_ranges = false,
+                           const std::vector<size_t>* index_map = nullptr) const;
     std::string detokenize(const std::vector<std::string>& words,
                            const std::vector<std::vector<std::string> >& features,
                            Ranges* ranges, bool merge_ranges = false) const;
+
+    void parse_tokens(const std::vector<std::string>& words,
+                      const std::vector<std::vector<std::string>>& features,
+                      std::vector<Token>& tokens,
+                      std::vector<size_t>* index_map = nullptr) const;
 
     bool has_left_join(const std::string& word) const;
     bool has_right_join(const std::string& word) const;

--- a/src/CaseModifier.cc
+++ b/src/CaseModifier.cc
@@ -265,7 +265,7 @@ namespace onmt
         if (false
             || (!soft
                 && case_type == Type::Uppercase
-                && token.subword)
+                && token.type == TokenType::TrailingSubword)
             || (soft
                 && (case_type == Type::Uppercase
                     || (case_type == Type::Capitalized && token.unicode_length() == 1)

--- a/src/CaseModifier.cc
+++ b/src/CaseModifier.cc
@@ -1,5 +1,7 @@
 #include "onmt/CaseModifier.h"
 
+#include <algorithm>
+
 #include "onmt/Tokenizer.h"
 #include "onmt/unicode/Unicode.h"
 
@@ -192,19 +194,124 @@ namespace onmt
     return (Tokenizer::ph_marker_open + name + Tokenizer::ph_marker_close);
   }
 
-  std::string CaseModifier::generate_case_markup(CaseModifier::Type type)
+  std::string CaseModifier::generate_case_markup(Markup markup, Type type)
   {
-    return build_placeholder(case_markup_prefix + type_to_char(type));
+    const std::string* markup_prefix = nullptr;
+    switch (markup)
+    {
+    case Markup::Modifier:
+      markup_prefix = &case_markup_prefix;
+      break;
+    case Markup::RegionBegin:
+      markup_prefix = &case_markup_begin_prefix;
+      break;
+    case Markup::RegionEnd:
+      markup_prefix = &case_markup_end_prefix;
+      break;
+    default:
+      return "";
+    }
+
+    return build_placeholder(*markup_prefix + type_to_char(type));
   }
 
-  std::string CaseModifier::generate_case_markup_begin(CaseModifier::Type type)
+
+  // Returns true if the token at offset can be connected to an uppercase token or
+  // capital letter. This useful to avoid closing an uppercase region if intermediate
+  // tokens are case invariant.
+  static bool has_connected_uppercase(const std::vector<Token>& tokens, size_t offset)
   {
-    return build_placeholder(case_markup_begin_prefix + type_to_char(type));
+    for (size_t j = offset + 1; j < tokens.size(); ++j)
+    {
+      auto case_type = tokens[j].case_type;
+      if (case_type == CaseModifier::Type::Uppercase
+          || (case_type == CaseModifier::Type::Capitalized && tokens[j].unicode_length() == 1))
+        return true;
+      else if (case_type != CaseModifier::Type::None)
+        break;
+    }
+    return false;
   }
 
-  std::string CaseModifier::generate_case_markup_end(CaseModifier::Type type)
+  // Returns true if token only contains numbers.
+  static bool numbers_only(const std::string& token)
   {
-    return build_placeholder(case_markup_end_prefix + type_to_char(type));
+    std::vector<std::string> chars;
+    std::vector<unicode::code_point_t> code_points;
+    unicode::explode_utf8(token, chars, code_points);
+    return std::all_of(code_points.begin(), code_points.end(), unicode::is_number);
+  }
+
+  std::vector<CaseModifier::TokenMarkup>
+  CaseModifier::get_case_markups(const std::vector<Token>& tokens, const bool soft)
+  {
+    std::vector<TokenMarkup> markups;
+    markups.reserve(tokens.size());
+    bool in_uppercase_region = false;
+
+    for (size_t i = 0; i < tokens.size(); ++i)
+    {
+      const Token& token = tokens[i];
+      auto case_type = token.case_type;
+      auto markup_prefix = Markup::None;
+      auto markup_suffix = Markup::None;
+
+      if (in_uppercase_region)
+      {
+        // In legacy mode, we end the region if the token is not uppercase or does not belong
+        // to the same word before subtokenization.
+        // In soft mode, we end the region on lowercase tokens or case invariant tokens that
+        // are not numbers or not followed by another uppercase sequence.
+        if (false
+            || (!soft
+                && case_type == Type::Uppercase
+                && token.subword)
+            || (soft
+                && (case_type == Type::Uppercase
+                    || (case_type == Type::Capitalized && token.unicode_length() == 1)
+                    || (case_type == Type::None
+                        && !Tokenizer::is_placeholder(token.surface)
+                        && (has_connected_uppercase(tokens, i)
+                            || numbers_only(token.surface))))))
+        {
+          case_type = Type::Uppercase;
+        }
+        else
+        {
+          markups.back().suffix = Markup::RegionEnd;
+          in_uppercase_region = false;
+          // Rewind index to treat token in the other branch.
+          --i;
+          continue;
+        }
+      }
+      else
+      {
+        // In soft mode, we begin region on uppercase tokens or capital letter that are
+        // followed by another uppercase sequence.
+        if (case_type == Type::Uppercase
+            || (soft
+                && case_type == Type::Capitalized
+                && token.unicode_length() == 1
+                && has_connected_uppercase(tokens, i)))
+        {
+          case_type = Type::Uppercase;
+          markup_prefix = Markup::RegionBegin;
+          in_uppercase_region = true;
+        }
+        else if (case_type == Type::Capitalized)
+        {
+          markup_prefix = Markup::Modifier;
+        }
+      }
+
+      markups.emplace_back(markup_prefix, markup_suffix, case_type);
+    }
+
+    if (in_uppercase_region)
+      markups.back().suffix = Markup::RegionEnd;
+
+    return markups;
   }
 
 }

--- a/src/SubwordEncoder.cc
+++ b/src/SubwordEncoder.cc
@@ -94,11 +94,9 @@ namespace onmt
         tokens.back().preserve = true;
     }
 
-    for (size_t i = 0; i < tokens.size(); ++i)
+    if (token.has_case())
     {
-      if (i > 0)
-        tokens[i].subword = true;
-      if (token.has_case())
+      for (size_t i = 0; i < tokens.size(); ++i)
       {
         auto case_type = token.case_type;
         if (case_type == CaseModifier::Type::Capitalized && i > 0)
@@ -107,6 +105,13 @@ namespace onmt
           case_type = CaseModifier::extract_case_type(tokens[i].surface).second;
         tokens[i].case_type = case_type;
       }
+    }
+
+    if (tokens.size() > 1)
+    {
+      tokens.front().type = TokenType::LeadingSubword;
+      for (size_t i = 1; i < tokens.size(); ++i)
+        tokens[i].type = TokenType::TrailingSubword;
     }
 
     if (token.has_features())

--- a/src/SubwordEncoder.cc
+++ b/src/SubwordEncoder.cc
@@ -94,9 +94,11 @@ namespace onmt
         tokens.back().preserve = true;
     }
 
-    if (token.has_case())
+    for (size_t i = 0; i < tokens.size(); ++i)
     {
-      for (size_t i = 0; i < tokens.size(); ++i)
+      if (i > 0)
+        tokens[i].subword = true;
+      if (token.has_case())
       {
         auto case_type = token.case_type;
         if (case_type == CaseModifier::Type::Capitalized && i > 0)
@@ -104,12 +106,6 @@ namespace onmt
         else if (case_type == CaseModifier::Type::Mixed)
           case_type = CaseModifier::extract_case_type(tokens[i].surface).second;
         tokens[i].case_type = case_type;
-      }
-
-      if (token.begins_case_region())
-      {
-        tokens.front().begin_case_region = token.case_type;
-        tokens.back().end_case_region = token.case_type;
       }
     }
 

--- a/src/Tokenizer.cc
+++ b/src/Tokenizer.cc
@@ -87,6 +87,14 @@ namespace onmt
     }
   }
 
+  static inline void clear_token(Token& token)
+  {
+    token.surface.clear();
+    token.join_right = false;
+    token.join_left = false;
+    token.preserve = false;
+  }
+
   template <typename T>
   std::string int_to_hex(T i, int width = 4)
   {
@@ -531,7 +539,7 @@ namespace onmt
             if (_preserve_segmented_tokens)
               token.preserve = true;
             tokens.emplace_back(std::move(token));
-            token.clear();
+            clear_token(token);
           }
 
           token.append(c);
@@ -556,7 +564,7 @@ namespace onmt
           if (_preserve_placeholders || _preserve_segmented_tokens)
             token.preserve = true;
           tokens.emplace_back(std::move(token));
-          token.clear();
+          clear_token(token);
           in_placeholder = false;
         }
       }
@@ -643,7 +651,7 @@ namespace onmt
           } else {
             token.join_right = true;
             annotated_tokens.emplace_back(std::move(token));
-            token.clear();
+            clear_token(token);
             state = State::Space;
             continue;
           }
@@ -687,7 +695,7 @@ namespace onmt
           if (!space)
           {
             annotated_tokens.emplace_back(std::move(token));
-            token.clear();
+            clear_token(token);
           }
 
           if (v == 0x200D) // Zero-Width joiner.
@@ -696,7 +704,7 @@ namespace onmt
               annotated_tokens.back().join_right = true;
             else
             {
-              token.clear();
+              clear_token(token);
               token.join_left = true;
             }
           }
@@ -706,7 +714,7 @@ namespace onmt
             if (!unicode::is_separator(next_v))
             {
               annotated_tokens.emplace_back(std::move(token));
-              token.clear();
+              clear_token(token);
             }
           }
 
@@ -764,7 +772,7 @@ namespace onmt
                     && (segment_case || segment_alphabet || segment_alphabet_change))
                   token.preserve = true;
                 annotated_tokens.emplace_back(std::move(token));
-                token.clear();
+                clear_token(token);
                 uppercase = (type_letter == unicode::_letter_upper);
                 uppercase_sequence = false;
               }
@@ -811,12 +819,12 @@ namespace onmt
               if (!space)
               {
                 annotated_tokens.emplace_back(std::move(token));
-                token.clear();
+                clear_token(token);
                 token.join_left = true;
               }
               else if (other)
               {
-                token.clear();
+                clear_token(token);
                 token.join_left = true;
               }
 
@@ -826,7 +834,7 @@ namespace onmt
                 token.append(sub_c);
 
               annotated_tokens.emplace_back(std::move(token));
-              token.clear();
+              clear_token(token);
               uppercase = false;
               uppercase_sequence = false;
               state = State::Other | State::Space;

--- a/test/test.cc
+++ b/test/test.cc
@@ -330,6 +330,8 @@ TEST(TokenizerTest, CaseMarkupWithJoiners) {
   test_tok_and_detok(tokenizer,
                      "Hello WORLD!", "｟mrk_case_modifier_C｠ hello ｟mrk_begin_case_region_U｠ world ｟mrk_end_case_region_U｠ ￭!");
   test_tok_and_detok(tokenizer,
+                     "HELLO WORLD!", "｟mrk_begin_case_region_U｠ hello ｟mrk_end_case_region_U｠ ｟mrk_begin_case_region_U｠ world ｟mrk_end_case_region_U｠ ￭!");
+  test_tok_and_detok(tokenizer,
                      "Hello WOrld!", "｟mrk_case_modifier_C｠ hello ｟mrk_begin_case_region_U｠ wo￭ ｟mrk_end_case_region_U｠ rld ￭!");
   test_tok_and_detok(tokenizer,
                      "hello woRld!", "hello wo￭ ｟mrk_case_modifier_C｠ rld ￭!");


### PR DESCRIPTION
* Case regions are serialization details and should not be properties of the class
* The index attribute was only used for the detokenization with ranges because it was convenient, but it should not be a property