### PR TITLE
Add flag to return ranges on Unicode characters

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -72,11 +72,14 @@ tokenizer.detokenize(
 ) -> str
 
 # The detokenize_with_ranges method also returns a dictionary mapping a token
-# index to a range in the detokenized text. Set merge_ranges=True to merge
-# consecutive ranges, e.g. subwords of the same token in case of subword tokenization.
+# index to a range in the detokenized text.
+# Set merge_ranges=True to merge consecutive ranges, e.g. subwords of the same
+# token in case of subword tokenization.
+# Set unicode_ranges=True to return ranges over Unicode characters instead of bytes.
 tokenizer.detokenize_with_ranges(
     tokens: Union[List[str], List[pyonmttok.Token]],
-    merge_ranges: bool = True
+    merge_ranges: bool = True,
+    unicode_ranges: bool = True
 ) -> Tuple[str, Dict[int, Pair[int, int]]]
 
 # Detokenize a file.

--- a/bindings/python/test/test.py
+++ b/bindings/python/test/test.py
@@ -126,6 +126,18 @@ def test_detok_with_ranges():
     assert ranges[0] == (0, 0)
     assert ranges[1] == (2, 2)
 
+    _, ranges = tokenizer.detokenize_with_ranges(
+        ["测", "试"], unicode_ranges=True)
+    assert len(ranges) == 2
+    assert ranges[0] == (0, 0)
+    assert ranges[1] == (2, 2)
+
+    _, ranges = tokenizer.detokenize_with_ranges(
+        ["测", "￭试"], unicode_ranges=True, merge_ranges=True)
+    assert len(ranges) == 2
+    assert ranges[0] == (0, 1)
+    assert ranges[1] == (0, 1)
+
 def test_bpe_case_insensitive_issue_147():
     tokenizer = pyonmttok.Tokenizer(
         "conservative",


### PR DESCRIPTION
We only expose this flag in the Python API where it is the most useful.

Closes #158.