### PR TITLE
Rename SPMLearner to SentencePieceLearner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ set(PUBLIC_HEADERS
   include/onmt/ITokenizer.h
   include/onmt/SPMLearner.h
   include/onmt/SentencePiece.h
+  include/onmt/SentencePieceLearner.h
   include/onmt/SpaceTokenizer.h
   include/onmt/SubwordEncoder.h
   include/onmt/SubwordLearner.h
@@ -70,8 +71,8 @@ set(SOURCES
   src/BPELearner.cc
   src/Casing.cc
   src/ITokenizer.cc
-  src/SPMLearner.cc
   src/SentencePiece.cc
+  src/SentencePieceLearner.cc
   src/SpaceTokenizer.cc
   src/SubwordEncoder.cc
   src/SubwordLearner.cc

--- a/bindings/python/Python.cc
+++ b/bindings/python/Python.cc
@@ -10,7 +10,7 @@
 #include <onmt/BPE.h>
 #include <onmt/SentencePiece.h>
 #include <onmt/BPELearner.h>
-#include <onmt/SPMLearner.h>
+#include <onmt/SentencePieceLearner.h>
 
 namespace py = pybind11;
 
@@ -430,10 +430,10 @@ public:
                               bool keep_vocab,
                               py::kwargs kwargs)
     : SubwordLearnerWrapper(tokenizer,
-                            new onmt::SPMLearner(false,
-                                                 parse_kwargs(kwargs),
-                                                 create_temp_file(),
-                                                 keep_vocab))
+                            new onmt::SentencePieceLearner(false,
+                                                           parse_kwargs(kwargs),
+                                                           create_temp_file(),
+                                                           keep_vocab))
     , _keep_vocab(keep_vocab)
   {
   }

--- a/cli/learn.cc
+++ b/cli/learn.cc
@@ -6,7 +6,7 @@
 
 #include <onmt/Tokenizer.h>
 #include <onmt/BPELearner.h>
-#include <onmt/SPMLearner.h>
+#include <onmt/SentencePieceLearner.h>
 
 #include "tokenization_args.h"
 
@@ -93,10 +93,10 @@ int main(int argc, char* argv[])
 
   }
   else if (subword == "sentencepiece") {
-    learner = new onmt::SPMLearner(vm["verbose"].as<bool>(),
-                                   std::vector<std::string>(subword_args.begin() + 1,
-                                                            subword_args.end()),
-                                   vm["tmpfile"].as<std::string>());
+    learner = new onmt::SentencePieceLearner(vm["verbose"].as<bool>(),
+                                             std::vector<std::string>(subword_args.begin() + 1,
+                                                                      subword_args.end()),
+                                             vm["tmpfile"].as<std::string>());
     return 1;
   }
   else {

--- a/include/onmt/SPMLearner.h
+++ b/include/onmt/SPMLearner.h
@@ -1,45 +1,10 @@
+// Deprecated, use SentencePieceLearner instead.
+
 #pragma once
 
-#include <fstream>
-#include <memory>
-#include <unordered_map>
-
-#include "onmt/opennmttokenizer_export.h"
-#include "onmt/SubwordLearner.h"
+#include "onmt/SentencePieceLearner.h"
 
 namespace onmt
 {
-
-  class OPENNMTTOKENIZER_EXPORT SPMLearner: public SubwordLearner
-  {
-  public:
-    SPMLearner(bool verbose,
-               const std::string& opts,
-               const std::string& input_filename,
-               bool keep_vocab = false);
-    SPMLearner(bool verbose,
-               const std::vector<std::string>& opts,
-               const std::string& input_filename,
-               bool keep_vocab = false);
-    SPMLearner(bool verbose,
-               const std::unordered_map<std::string, std::string>& opts,
-               const std::string& input_filename,
-               bool keep_vocab = false);
-    ~SPMLearner();
-
-    void set_input_filename(const std::string& filename);
-
-    void learn(std::ostream& os, const char* description = 0, bool verbose = false) override;
-    void learn(const std::string& model_path,
-               const char* description = 0,
-               bool verbose = false) override;
-  protected:
-    void ingest_token_impl(const std::string& token) final;
-  private:
-    std::string _args;
-    std::string _input_filename;
-    bool _keep_vocab;
-    std::unique_ptr<std::ofstream> _input_stream;
-  };
-
+  using SPMLearner = SentencePieceLearner;
 }

--- a/include/onmt/SentencePieceLearner.h
+++ b/include/onmt/SentencePieceLearner.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <fstream>
+#include <memory>
+#include <unordered_map>
+
+#include "onmt/opennmttokenizer_export.h"
+#include "onmt/SubwordLearner.h"
+
+namespace onmt
+{
+
+  class OPENNMTTOKENIZER_EXPORT SentencePieceLearner: public SubwordLearner
+  {
+  public:
+    SentencePieceLearner(bool verbose,
+                         const std::string& opts,
+                         const std::string& input_filename,
+                         bool keep_vocab = false);
+    SentencePieceLearner(bool verbose,
+                         const std::vector<std::string>& opts,
+                         const std::string& input_filename,
+                         bool keep_vocab = false);
+    SentencePieceLearner(bool verbose,
+                         const std::unordered_map<std::string, std::string>& opts,
+                         const std::string& input_filename,
+                         bool keep_vocab = false);
+    ~SentencePieceLearner();
+
+    void set_input_filename(const std::string& filename);
+
+    void learn(std::ostream& os, const char* description = 0, bool verbose = false) override;
+    void learn(const std::string& model_path,
+               const char* description = 0,
+               bool verbose = false) override;
+  protected:
+    void ingest_token_impl(const std::string& token) final;
+  private:
+    std::string _args;
+    std::string _input_filename;
+    bool _keep_vocab;
+    std::unique_ptr<std::ofstream> _input_stream;
+  };
+
+}

--- a/src/SentencePieceLearner.cc
+++ b/src/SentencePieceLearner.cc
@@ -1,14 +1,14 @@
-#include "onmt/SPMLearner.h"
+#include "onmt/SentencePieceLearner.h"
 
 #include <sentencepiece_trainer.h>
 
 namespace onmt
 {
 
-  SPMLearner::SPMLearner(bool verbose,
-                         const std::string& opts,
-                         const std::string& input_filename,
-                         bool keep_vocab)
+  SentencePieceLearner::SentencePieceLearner(bool verbose,
+                                             const std::string& opts,
+                                             const std::string& input_filename,
+                                             bool keep_vocab)
     : SubwordLearner(verbose)
     , _args(opts)
     , _input_filename(input_filename)
@@ -16,10 +16,10 @@ namespace onmt
   {
   }
 
-  SPMLearner::SPMLearner(bool verbose,
-                         const std::vector<std::string>& opts,
-                         const std::string& input_filename,
-                         bool keep_vocab)
+  SentencePieceLearner::SentencePieceLearner(bool verbose,
+                                             const std::vector<std::string>& opts,
+                                             const std::string& input_filename,
+                                             bool keep_vocab)
     : SubwordLearner(verbose)
     , _input_filename(input_filename)
     , _keep_vocab(keep_vocab)
@@ -28,10 +28,10 @@ namespace onmt
       _args += opts[i] + "=" + opts[i + 1] + " ";
   }
 
-  SPMLearner::SPMLearner(bool verbose,
-                         const std::unordered_map<std::string, std::string>& opts,
-                         const std::string& input_filename,
-                         bool keep_vocab)
+  SentencePieceLearner::SentencePieceLearner(bool verbose,
+                                             const std::unordered_map<std::string, std::string>& opts,
+                                             const std::string& input_filename,
+                                             bool keep_vocab)
     : SubwordLearner(verbose)
     , _input_filename(input_filename)
     , _keep_vocab(keep_vocab)
@@ -40,26 +40,26 @@ namespace onmt
       _args += " --" + pair.first + "=" + pair.second;
   }
 
-  SPMLearner::~SPMLearner()
+  SentencePieceLearner::~SentencePieceLearner()
   {
     remove(_input_filename.c_str());
   }
 
-  void SPMLearner::set_input_filename(const std::string& filename)
+  void SentencePieceLearner::set_input_filename(const std::string& filename)
   {
     if (_input_stream)
       _input_stream.reset();
     _input_filename = filename;
   }
 
-  void SPMLearner::ingest_token_impl(const std::string& token)
+  void SentencePieceLearner::ingest_token_impl(const std::string& token)
   {
     if (!_input_stream)
       _input_stream.reset(new std::ofstream(_input_filename));
     *_input_stream << token << '\n';
   }
 
-  void SPMLearner::learn(std::ostream& os, const char* description, bool verbose)
+  void SentencePieceLearner::learn(std::ostream& os, const char* description, bool verbose)
   {
     if (_keep_vocab)
       throw std::invalid_argument("stream API does not support keeping the SentencePiece vocabulary");
@@ -71,7 +71,7 @@ namespace onmt
     remove(model_path.c_str());
   }
 
-  void SPMLearner::learn(const std::string& model_path, const char*, bool verbose)
+  void SentencePieceLearner::learn(const std::string& model_path, const char*, bool verbose)
   {
     verbose = verbose || _verbose;
     _input_stream->flush();


### PR DESCRIPTION
Keep previous header and symbol for backward compatibility.