### PR TITLE
Declare tokenization options when setting a subword vocabulary

### DIFF
--- a/bindings/python/Python.cc
+++ b/bindings/python/Python.cc
@@ -134,9 +134,6 @@ public:
       vocabulary_threshold = bpe_vocab_threshold;
     }
 
-    if (subword_encoder && !vocabulary_path.empty())
-      subword_encoder->load_vocabulary(vocabulary_path, vocabulary_threshold);
-
     onmt::Tokenizer::Options options;
     options.mode = onmt::Tokenizer::str_to_mode(mode);
     options.no_substitution = no_substitution;
@@ -157,8 +154,11 @@ public:
     if (!segment_alphabet.is(py::none()))
       options.segment_alphabet = to_std_vector<std::string>(segment_alphabet.cast<py::list>());
 
+    if (subword_encoder && !vocabulary_path.empty())
+      subword_encoder->load_vocabulary(vocabulary_path, vocabulary_threshold, &options);
+
     _tokenizer.reset(new onmt::Tokenizer(options,
-                                         std::shared_ptr<onmt::SubwordEncoder>(subword_encoder)));
+                                         std::shared_ptr<const onmt::SubwordEncoder>(subword_encoder)));
   }
 
   py::object tokenize(const std::string& text, const bool as_token_objects) const
@@ -344,7 +344,7 @@ public:
 
     auto* new_subword_encoder = create_subword_encoder(model_path);
     auto* new_tokenizer = new onmt::Tokenizer(*_tokenizer);
-    new_tokenizer->set_subword_encoder(std::shared_ptr<onmt::SubwordEncoder>(new_subword_encoder));
+    new_tokenizer->set_subword_encoder(std::shared_ptr<const onmt::SubwordEncoder>(new_subword_encoder));
     return TokenizerWrapper(new_tokenizer);
   }
 

--- a/cli/tokenize.cc
+++ b/cli/tokenize.cc
@@ -87,10 +87,11 @@ int main(int argc, char* argv[])
                                                 vm["sp_alpha"].as<float>());
   }
 
+  auto options = build_tokenization_options(vm);
   if (subword_encoder && !vocabulary.empty())
-    subword_encoder->load_vocabulary(vocabulary, vocabulary_threshold);
+    subword_encoder->load_vocabulary(vocabulary, vocabulary_threshold, &options);
 
-  onmt::Tokenizer tokenizer(build_tokenization_options(vm),
+  onmt::Tokenizer tokenizer(std::move(options),
                             std::shared_ptr<onmt::SubwordEncoder>(subword_encoder));
 
   tokenizer.tokenize_stream(std::cin, std::cout, vm["num_threads"].as<int>());

--- a/docs/options.md
+++ b/docs/options.md
@@ -181,11 +181,6 @@ The following line formats are accepted:
 * `<token><tab><frequency>`
 * `<token>` (the token frequency is set to 1)
 
-This feature currently requires subword encoders to be used with their "natural" tokenization settings, that is:
-
-* SentencePiece: `--mode none --spacer_annotate`
-* BPE: `--joiner_annotate`
-
 ### `vocabulary_threshold` (int, default: `0`)
 
 When using `vocabulary_path`, any words with a frequency lower than `vocabulary_threshold` will be treated as OOV.

--- a/include/onmt/BPE.h
+++ b/include/onmt/BPE.h
@@ -20,12 +20,13 @@ namespace onmt
     std::vector<std::string> encode(const std::string& str) const override;
     std::vector<Token> encode_and_annotate(const Token& token) const override;
 
-    void set_vocabulary(const std::vector<std::string>& vocabulary) override;
+    void set_vocabulary(const std::vector<std::string>& vocabulary,
+                        const Tokenizer::Options* options = nullptr) override;
     void reset_vocabulary() override;
 
     void set_joiner(const std::string& joiner)
     {
-      _joiner = joiner;
+      _tokenization_options.joiner = joiner;
     }
 
     void set_dropout(const float dropout)
@@ -40,9 +41,10 @@ namespace onmt
     bool _suffix;
     bool _case_insensitive;
     std::pair<int, int> _version;
-
-    std::string _joiner;
     float _dropout;
+
+    // Tokenization options used to produce the vocabulary passed to set_vocabulary.
+    Tokenizer::Options _tokenization_options;
 
     std::unordered_map<std::string, int> _codes;
     std::unordered_map<std::string, std::pair<std::string, std::string> > _codes_reverse;

--- a/include/onmt/SentencePiece.h
+++ b/include/onmt/SentencePiece.h
@@ -18,7 +18,9 @@ namespace onmt
     SentencePiece(const std::string& model_path, int nbest_size, float alpha);
     ~SentencePiece();
 
-    void set_vocabulary(const std::vector<std::string>& vocabulary) override;
+    void update_tokenization_options(Tokenizer::Options& options) const override;
+    void set_vocabulary(const std::vector<std::string>& vocabulary,
+                        const Tokenizer::Options* options = nullptr) override;
     void reset_vocabulary() override;
     void enable_regularization(int nbest_size, float alpha);
 

--- a/include/onmt/SubwordEncoder.h
+++ b/include/onmt/SubwordEncoder.h
@@ -4,7 +4,7 @@
 #include <vector>
 
 #include "onmt/opennmttokenizer_export.h"
-#include "onmt/Token.h"
+#include "onmt/Tokenizer.h"
 
 namespace onmt
 {
@@ -14,8 +14,14 @@ namespace onmt
   public:
     virtual ~SubwordEncoder() = default;
 
-    virtual void load_vocabulary(const std::string& path, int frequency_threshold);
-    virtual void set_vocabulary(const std::vector<std::string>& vocabulary);
+    // Maybe update the tokenization options for this subword encoder.
+    virtual void update_tokenization_options(Tokenizer::Options& options) const;
+
+    virtual void load_vocabulary(const std::string& path,
+                                 int frequency_threshold,
+                                 const Tokenizer::Options* tokenization_options = nullptr);
+    virtual void set_vocabulary(const std::vector<std::string>& vocabulary,
+                                const Tokenizer::Options* tokenization_options = nullptr);
     virtual void reset_vocabulary();
 
     virtual std::vector<std::string> encode(const std::string& str) const = 0;

--- a/include/onmt/Tokenizer.h
+++ b/include/onmt/Tokenizer.h
@@ -6,12 +6,14 @@
 
 #include "onmt/opennmttokenizer_export.h"
 #include "onmt/ITokenizer.h"
-#include "onmt/SubwordEncoder.h"
+#include "onmt/Token.h"
 
 namespace onmt
 {
 
   void set_random_seed(const unsigned int seed);
+
+  class SubwordEncoder;
 
   // This Tokenizer implements the behaviour of OpenNMT's tools/tokenize.lua.
   class OPENNMTTOKENIZER_EXPORT Tokenizer: public ITokenizer
@@ -61,7 +63,7 @@ namespace onmt
     static const std::string ph_marker_close;
 
     Tokenizer(Options options,
-              const std::shared_ptr<SubwordEncoder>& subword_encoder = nullptr);
+              const std::shared_ptr<const SubwordEncoder>& subword_encoder = nullptr);
 
     using ITokenizer::tokenize;
     using ITokenizer::detokenize;
@@ -94,7 +96,7 @@ namespace onmt
                            const std::vector<std::vector<std::string> >& features,
                            Ranges& ranges, bool merge_ranges = false) const override;
 
-    void set_subword_encoder(const std::shared_ptr<SubwordEncoder>& subword_encoder);
+    void set_subword_encoder(const std::shared_ptr<const SubwordEncoder>& subword_encoder);
 
     const Options& options() const
     {
@@ -106,7 +108,7 @@ namespace onmt
     static const int number_alphabet = -3;
 
     Options _options;
-    std::shared_ptr<SubwordEncoder> _subword_encoder;
+    std::shared_ptr<const SubwordEncoder> _subword_encoder;
 
     void tokenize_on_placeholders(const std::string& text,
                                   std::vector<Token>& annotated_tokens) const;
@@ -171,7 +173,7 @@ namespace onmt
     // External subword encoder constructor.
     // Note: the tokenizer takes ownership of the subword_encoder pointer.
     Tokenizer(Mode mode,
-              SubwordEncoder* subword_encoder,
+              const SubwordEncoder* subword_encoder,
               int flags = Flags::None,
               const std::string& joiner = joiner_marker);
 

--- a/src/SentencePiece.cc
+++ b/src/SentencePiece.cc
@@ -42,8 +42,28 @@ namespace onmt
     delete _processor;
   }
 
-  void SentencePiece::set_vocabulary(const std::vector<std::string>& vocabulary)
+  void SentencePiece::update_tokenization_options(Tokenizer::Options& options) const
   {
+    // Maybe enable SentencePiece compatibility mode.
+    if (options.mode == Tokenizer::Mode::None
+        && !options.joiner_annotate
+        && !options.spacer_annotate)
+    {
+      options.spacer_annotate = true;
+      options.no_substitution = true;
+    }
+  }
+
+  void SentencePiece::set_vocabulary(const std::vector<std::string>& vocabulary,
+                                     const Tokenizer::Options* options)
+  {
+    if (options
+        && (options->mode != Tokenizer::Mode::None
+            || !options->spacer_annotate
+            || options->spacer_new))
+      throw std::invalid_argument("SentencePiece vocabulary restriction requires the tokenization "
+                                  "to use the \"none\" mode and \"spacer_annotate\" "
+                                  "(same as spm_encode)");
     auto status = _processor->SetVocabulary(vocabulary);
     if (!status.ok())
       throw std::invalid_argument(status.ToString());

--- a/src/SubwordEncoder.cc
+++ b/src/SubwordEncoder.cc
@@ -8,7 +8,13 @@
 namespace onmt
 {
 
-  void SubwordEncoder::load_vocabulary(const std::string& path, int frequency_threshold)
+  void SubwordEncoder::update_tokenization_options(Tokenizer::Options&) const
+  {
+  }
+
+  void SubwordEncoder::load_vocabulary(const std::string& path,
+                                       int frequency_threshold,
+                                       const Tokenizer::Options* options)
   {
     std::ifstream in(path);
     if (!in)
@@ -39,17 +45,15 @@ namespace onmt
         vocab.emplace_back(std::move(token));
     }
 
-    set_vocabulary(vocab);
+    set_vocabulary(vocab, options);
   }
 
-  void SubwordEncoder::set_vocabulary(const std::vector<std::string>&)
+  void SubwordEncoder::set_vocabulary(const std::vector<std::string>&, const Tokenizer::Options*)
   {
-    return;
   }
 
   void SubwordEncoder::reset_vocabulary()
   {
-    return;
   }
 
   std::vector<Token> SubwordEncoder::encode_and_annotate(const std::vector<Token>& tokens) const

--- a/test/test.cc
+++ b/test/test.cc
@@ -580,6 +580,18 @@ TEST(TokenizerTest, BPEVocabularyWithLeadingJoiner) {
   test_tok(tokenizer, "A100", "A ￭1￭ 0￭ 0");
 }
 
+TEST(TokenizerTest, BPEVocabularyWithSpacer) {
+  Tokenizer::Options options;
+  options.mode = Tokenizer::Mode::Space;
+  options.spacer_annotate = true;
+
+  auto bpe = std::make_shared<BPE>(get_data("bpe-models/bpe_code.v0.2"));
+  bpe->set_vocabulary(std::vector<std::string>{"▁wel"}, &options);
+  Tokenizer tokenizer(options, bpe);
+
+  test_tok(tokenizer, "die welle", "d i e ▁wel l e");
+}
+
 TEST(TokenizerTest, SpacerAnnotate) {
   Tokenizer tokenizer(Tokenizer::Mode::Aggressive, Tokenizer::Flags::SpacerAnnotate);
   test_tok_and_detok(tokenizer,


### PR DESCRIPTION
This is required to make BPE vocabulary restriction work with spacer_annotate, joiner_new, etc.

This PR also make the subword encoder `const` when assigned to a tokenizer instance.