### PR TITLE
Do not require "none" mode for SentencePiece vocabulary restriction

### DIFF
--- a/bindings/python/test/test.py
+++ b/bindings/python/test/test.py
@@ -104,11 +104,6 @@ def test_sp_with_vocabulary(tmpdir):
     with open(vocab_path, "w") as vocab_file:
         vocab_file.write("▁Wor\n")
 
-    with pytest.raises(ValueError, match="none"):
-        tokenizer = pyonmttok.Tokenizer(
-            mode="conservative",
-            sp_model_path=sp_model_path,
-            vocabulary_path=vocab_path)
     with pytest.raises(ValueError, match="spacer_annotate"):
         tokenizer = pyonmttok.Tokenizer(
             mode="none",

--- a/src/SentencePiece.cc
+++ b/src/SentencePiece.cc
@@ -57,13 +57,9 @@ namespace onmt
   void SentencePiece::set_vocabulary(const std::vector<std::string>& vocabulary,
                                      const Tokenizer::Options* options)
   {
-    if (options
-        && (options->mode != Tokenizer::Mode::None
-            || options->joiner_annotate
-            || options->spacer_new))
+    if (options && (options->joiner_annotate || options->spacer_new))
       throw std::invalid_argument("SentencePiece vocabulary restriction requires the tokenization "
-                                  "to use the \"none\" mode and \"spacer_annotate\" "
-                                  "(same as spm_encode)");
+                                  "to use \"spacer_annotate\" (same as spm_encode)");
     auto status = _processor->SetVocabulary(vocabulary);
     if (!status.ok())
       throw std::invalid_argument(status.ToString());


### PR DESCRIPTION
It should work as long as spacer_annotate is used.