### PR TITLE
Split characters into CharInfo objects

### DIFF
--- a/include/onmt/BPE.h
+++ b/include/onmt/BPE.h
@@ -7,6 +7,7 @@
 
 #include "onmt/opennmttokenizer_export.h"
 #include "onmt/SubwordEncoder.h"
+#include "onmt/unicode/Unicode.h"
 
 namespace onmt
 {
@@ -33,6 +34,9 @@ namespace onmt
     {
       _dropout = dropout;
     }
+
+    static std::vector<std::string> get_initial_pieces(const std::vector<unicode::CharInfo>& chars,
+                                                       const bool lowercase = false);
 
   private:
     std::string _end_of_word;

--- a/include/onmt/Token.h
+++ b/include/onmt/Token.h
@@ -42,9 +42,10 @@ namespace onmt
     {
     }
 
-    void append(const std::string& str)
+    template <typename... Args>
+    void append(Args&&... args)
     {
-      surface += str;
+      surface.append(std::forward<Args>(args)...);
     }
 
     bool empty() const

--- a/include/onmt/unicode/Unicode.h
+++ b/include/onmt/unicode/Unicode.h
@@ -16,19 +16,18 @@ namespace onmt
     OPENNMTTOKENIZER_EXPORT std::string cp_to_utf8(code_point_t u);
     OPENNMTTOKENIZER_EXPORT code_point_t utf8_to_cp(const unsigned char* s, unsigned int &l);
 
-    OPENNMTTOKENIZER_EXPORT void explode_utf8(const std::string& str,
-                                              std::vector<std::string>& chars,
-                                              std::vector<code_point_t>& code_points);
-
-    OPENNMTTOKENIZER_EXPORT void
-    explode_utf8_with_marks(const std::string& str,
-                            std::vector<std::string>& chars,
-                            std::vector<code_point_t>* code_points_main = nullptr,
-                            std::vector<std::vector<code_point_t>>* code_points_combining = nullptr,
-                            const std::vector<code_point_t>* protected_chars = nullptr);
-
     OPENNMTTOKENIZER_EXPORT size_t utf8len(const std::string& str);
 
+    enum class CharType
+    {
+      Letter,
+      Mark,
+      Number,
+      Other,
+      Separator,
+    };
+
+    OPENNMTTOKENIZER_EXPORT CharType get_char_type(code_point_t u);
     OPENNMTTOKENIZER_EXPORT bool is_separator(code_point_t u);
     OPENNMTTOKENIZER_EXPORT bool is_letter(code_point_t u);
     OPENNMTTOKENIZER_EXPORT bool is_number(code_point_t u);
@@ -48,11 +47,56 @@ namespace onmt
     OPENNMTTOKENIZER_EXPORT const char* get_script_name(int script_code);
     OPENNMTTOKENIZER_EXPORT int get_script(code_point_t c);
 
+    struct OPENNMTTOKENIZER_EXPORT CharInfo
+    {
+      const char* data;
+      size_t length;
+      code_point_t value;
+      CharType char_type;
+      CaseType case_type;
+
+      CharInfo(const char* data_,
+               size_t length_,
+               code_point_t value_,
+               CharType char_type_,
+               CaseType case_type_)
+        : data(data_)
+        , length(length_)
+        , value(value_)
+        , char_type(char_type_)
+        , case_type(case_type_)
+      {
+      }
+
+      bool operator==(const std::string& str) const
+      {
+        return str.compare(0, str.size(), data, length) == 0;
+      }
+
+      bool operator==(char c) const
+      {
+        return static_cast<code_point_t>(c) == value;
+      }
+    };
+
+    OPENNMTTOKENIZER_EXPORT std::vector<CharInfo> get_characters_info(const std::string& str);
+
 
     // The symbols below are deprecated but kept for backward compatibility.
 
     OPENNMTTOKENIZER_EXPORT std::vector<std::string> split_utf8(const std::string& str,
                                                                 const std::string& sep);
+
+    OPENNMTTOKENIZER_EXPORT void explode_utf8(const std::string& str,
+                                              std::vector<std::string>& chars,
+                                              std::vector<code_point_t>& code_points);
+
+    OPENNMTTOKENIZER_EXPORT void
+    explode_utf8_with_marks(const std::string& str,
+                            std::vector<std::string>& chars,
+                            std::vector<code_point_t>* code_points_main = nullptr,
+                            std::vector<std::vector<code_point_t>>* code_points_combining = nullptr,
+                            const std::vector<code_point_t>* protected_chars = nullptr);
 
     inline void explode_utf8_with_marks(const std::string& str,
                                         std::vector<std::string>& chars,

--- a/src/BPELearner.cc
+++ b/src/BPELearner.cc
@@ -16,6 +16,7 @@ The code is converted from bpe_learn.py (https://github.com/rsennrich/subword-nm
 #include <limits>
 #include <unordered_set>
 
+#include "onmt/BPE.h"
 #include "onmt/unicode/Unicode.h"
 
 namespace onmt
@@ -260,8 +261,7 @@ namespace onmt
     for (const auto& pair : vocab) {
       const std::string& token = pair.first;
       const int frequency = pair.second;
-      sequence chars;
-      unicode::explode_utf8_with_marks(token, chars);
+      sequence chars = BPE::get_initial_pieces(unicode::get_characters_info(token));
       chars.back().append("</w>");
       char_vocab.emplace(-frequency, std::move(chars));
     }

--- a/src/Tokenizer.cc
+++ b/src/Tokenizer.cc
@@ -585,7 +585,6 @@ namespace onmt
       else
         append(protected_character + int_to_hex(character.value, hex_value_width));
     }
-
   };
 
   void Tokenizer::tokenize_on_placeholders(const std::string& text,

--- a/test/test.cc
+++ b/test/test.cc
@@ -145,6 +145,16 @@ TEST(TokenizerTest, NoneWithPlaceholders2) {
   test_tok(tokenizer, "Hello:｟World｠!", "Hello:￭ ｟World｠ ￭ !");
 }
 
+TEST(TokenizerTest, NonePlaceholderSpacesEscape) {
+  Tokenizer tokenizer(Tokenizer::Mode::None, Tokenizer::Flags::None);
+  test_tok(tokenizer, "｟a b c｠", "｟a％0020b％0020c｠");
+}
+
+TEST(TokenizerTest, NonePlaceholderSpacesNoEscape) {
+  Tokenizer tokenizer(Tokenizer::Mode::None, Tokenizer::Flags::NoSubstitution);
+  test_tok(tokenizer, "｟a b c｠", "｟a b c｠");
+}
+
 TEST(TokenizerTest, PreserveTokensInNoneMode) {
   Tokenizer tokenizer(Tokenizer::Mode::None,
                       Tokenizer::Flags::JoinerAnnotate


### PR DESCRIPTION
The CharInfo structure is a string view with additional metadata. It
helps for performance as the input string in not copied and character
properties are resolved only once. It also helps for code clarity as
all character metadata are packed together.