### PR TITLE
Remove code dealing with Zero Width Joiner

### DIFF
--- a/src/Tokenizer.cc
+++ b/src/Tokenizer.cc
@@ -772,17 +772,7 @@ namespace onmt
           if (!space)
             builder.segment();
 
-          if (v == 0x200D) // Zero-Width joiner.
-          {
-            if (other || (number && next_c && next_c->char_type == unicode::CharType::Letter))
-              builder.previous().join_right = true;
-            else
-            {
-              builder.segment();
-              builder.current().join_left = true;
-            }
-          }
-          else if (_options.with_separators)
+          if (_options.with_separators)
           {
             builder.append(c);
             if (!next_c || next_c->char_type != unicode::CharType::Separator)

--- a/test/test.cc
+++ b/test/test.cc
@@ -279,6 +279,11 @@ TEST(TokenizerTest, NoSubstitution) {
   test_tok(tokenizer, "｟tag：value with spaces｠", "｟tag：value with spaces｠");
 }
 
+TEST(TokenizerTest, ZeroWidthJoiner) {
+  Tokenizer tokenizer(Tokenizer::Mode::Conservative, Tokenizer::Flags::JoinerAnnotate);
+  test_tok_and_detok(tokenizer, "👨‍👩‍👦", "👨 ￭‍ ￭👩 ￭‍ ￭👦");
+}
+
 TEST(TokenizerTest, CombiningMark) {
   Tokenizer tokenizer(Tokenizer::Mode::Conservative, Tokenizer::Flags::JoinerAnnotate);
   test_tok_and_detok(tokenizer,


### PR DESCRIPTION
The code was inside the block dealing with separator characters, but ZWJ is not in the separator Unicode category.

This could be considered a bug, but:

* the behavior was there for many versions (since we integrated ICU)
* the current output is reasonable, reversible, and does not cause vocabulary or learning issues

A future improvement could be to escape this kind of formatting characters.