### PR TITLE
Fix Token deserialization for the general case

### DIFF
--- a/bindings/python/test/test.py
+++ b/bindings/python/test/test.py
@@ -296,6 +296,15 @@ def test_token_api_with_subword():
     _check_subword(tokens)
     assert serialized_tokens == tokenizer.serialize_tokens(tokens)[0]
 
+def test_token_deserialize_with_preserved_tokens():
+    tokenizer = pyonmttok.Tokenizer(
+        "conservative",
+        joiner_annotate=True,
+        segment_case=True,
+        preserve_segmented_tokens=True)
+    tokens = tokenizer.tokenize("HelloWorld", as_token_objects=True)
+    assert tokenizer.deserialize_tokens(*tokenizer.serialize_tokens(tokens)) == tokens
+
 def test_token_api_features():
     tokenizer = pyonmttok.Tokenizer("space")
     tokens = tokenizer.tokenize("a b", as_token_objects=True)

--- a/src/Tokenizer.cc
+++ b/src/Tokenizer.cc
@@ -348,10 +348,7 @@ namespace onmt
                                   const std::vector<std::vector<std::string>>& features,
                                   std::vector<Token>& tokens) const
   {
-    if (_subword_encoder)
-      tokenize(detokenize(words, features), tokens);
-    else
-      parse_tokens(words, features, tokens);
+    tokenize(detokenize(words, features), tokens);
   }
 
   void Tokenizer::parse_tokens(const std::vector<std::string>& words,


### PR DESCRIPTION
A re-tokenization is required to get the complete and correct Token representation.