### PR TITLE
Adds pointer checking

### DIFF
--- a/include/onmt/SentencePieceLearner.h
+++ b/include/onmt/SentencePieceLearner.h
@@ -16,15 +16,18 @@ namespace onmt
     SentencePieceLearner(bool verbose,
                          const std::string& opts,
                          const std::string& input_filename,
-                         bool keep_vocab = false);
+                         bool keep_vocab = false, 
+                         bool keep_input_file = false);
     SentencePieceLearner(bool verbose,
                          const std::vector<std::string>& opts,
                          const std::string& input_filename,
-                         bool keep_vocab = false);
+                         bool keep_vocab = false, 
+                         bool keep_input_file = false);
     SentencePieceLearner(bool verbose,
                          const std::unordered_map<std::string, std::string>& opts,
                          const std::string& input_filename,
-                         bool keep_vocab = false);
+                         bool keep_vocab = false, 
+                         bool keep_input_file = false);
     ~SentencePieceLearner();
 
     void set_input_filename(const std::string& filename);
@@ -40,6 +43,7 @@ namespace onmt
     std::string _input_filename;
     bool _keep_vocab;
     std::unique_ptr<std::ofstream> _input_stream;
+    bool _keep_input_file;
   };
 
 }

--- a/src/SentencePieceLearner.cc
+++ b/src/SentencePieceLearner.cc
@@ -8,21 +8,25 @@ namespace onmt
   SentencePieceLearner::SentencePieceLearner(bool verbose,
                                              const std::string& opts,
                                              const std::string& input_filename,
-                                             bool keep_vocab)
+                                             bool keep_vocab, 
+                                             bool keep_input_file)
     : SubwordLearner(verbose)
     , _args(opts)
     , _input_filename(input_filename)
-    , _keep_vocab(keep_vocab)
+    , _keep_vocab(keep_vocab) 
+    , _keep_input_file(keep_input_file)
   {
   }
 
   SentencePieceLearner::SentencePieceLearner(bool verbose,
                                              const std::vector<std::string>& opts,
                                              const std::string& input_filename,
-                                             bool keep_vocab)
+                                             bool keep_vocab, 
+                                             bool keep_input_file)
     : SubwordLearner(verbose)
     , _input_filename(input_filename)
-    , _keep_vocab(keep_vocab)
+    , _keep_vocab(keep_vocab) 
+    , _keep_input_file(keep_input_file)
   {
     for(size_t i = 0; i < opts.size(); i += 2)
       _args += opts[i] + "=" + opts[i + 1] + " ";
@@ -31,10 +35,12 @@ namespace onmt
   SentencePieceLearner::SentencePieceLearner(bool verbose,
                                              const std::unordered_map<std::string, std::string>& opts,
                                              const std::string& input_filename,
-                                             bool keep_vocab)
+                                             bool keep_vocab, 
+                                             bool keep_input_file)
     : SubwordLearner(verbose)
     , _input_filename(input_filename)
     , _keep_vocab(keep_vocab)
+    , _keep_input_file(keep_input_file)
   {
     for (const auto& pair : opts)
       _args += " --" + pair.first + "=" + pair.second;
@@ -42,7 +48,9 @@ namespace onmt
 
   SentencePieceLearner::~SentencePieceLearner()
   {
-    remove(_input_filename.c_str());
+    if (!_keep_input_file) {
+      remove(_input_filename.c_str());
+    }
   }
 
   void SentencePieceLearner::set_input_filename(const std::string& filename)
@@ -86,7 +94,7 @@ namespace onmt
       std::cerr.clear();
 
     // Cleanup the input file.
-    remove(_input_filename.c_str());
+    if (!_keep_input_file) { remove(_input_filename.c_str()); }
 
     std::string sp_model_path = model_path + ".model";
     std::string sp_vocab_path = model_path + ".vocab";

--- a/src/SentencePieceLearner.cc
+++ b/src/SentencePieceLearner.cc
@@ -82,6 +82,10 @@ namespace onmt
   void SentencePieceLearner::learn(const std::string& model_path, const char*, bool verbose)
   {
     verbose = verbose || _verbose;
+    if (_input_stream) {
+      _input_stream->flush();
+      _input_stream.reset();  // Freeze the input file for training.
+    }
 
     if (!verbose)
       std::cerr.setstate(std::ios_base::failbit);

--- a/src/SentencePieceLearner.cc
+++ b/src/SentencePieceLearner.cc
@@ -82,8 +82,6 @@ namespace onmt
   void SentencePieceLearner::learn(const std::string& model_path, const char*, bool verbose)
   {
     verbose = verbose || _verbose;
-    _input_stream->flush();
-    _input_stream.reset();  // Freeze the input file for training.
 
     if (!verbose)
       std::cerr.setstate(std::ios_base::failbit);


### PR DESCRIPTION
It seems the following tow lines in src/SentencePieceLearner.cc are unnecessary, 
```cpp
    _input_stream->flush();
    _input_stream.reset(); 
```
actully, the var `_input_stream` is not used, but when training sentencepiece model from a file, these two lines will cause a coredump, so shall we just remove them~?