### PR TITLE
Add SentencePieceTokenizer to the Python module

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -59,6 +59,15 @@ tokenizer = pyonmttok.Tokenizer(
     segment_alphabet_change: bool = False,
     segment_alphabet: Optional[List[str]] = None)
 
+# SentencePiece-compatible tokenizer.
+tokenizer = pyonmttok.SentencePieceTokenizer(
+    model_path: str,
+    vocabulary_path: str = "",
+    vocabulary_threshold: int = 0,
+    nbest_size: int = 0,
+    alpha: float = 0.1,
+)
+
 # Copy constructor.
 tokenizer = pyonmttok.Tokenizer(tokenizer: pyonmttok.Tokenizer)
 

--- a/bindings/python/pyonmttok/Python.cc
+++ b/bindings/python/pyonmttok/Python.cc
@@ -147,6 +147,8 @@ public:
                                          std::shared_ptr<const onmt::SubwordEncoder>(subword_encoder)));
   }
 
+  virtual ~TokenizerWrapper() = default;
+
   py::dict get_options() const
   {
     const auto& options = _tokenizer->get_options();
@@ -309,6 +311,42 @@ public:
 
 private:
   std::shared_ptr<const onmt::Tokenizer> _tokenizer;
+};
+
+static onmt::Tokenizer* build_sp_tokenizer(const std::string& model_path,
+                                           const std::string& vocabulary_path,
+                                           int vocabulary_threshold,
+                                           int nbest_size,
+                                           float alpha)
+{
+  onmt::Tokenizer::Options options;
+  options.mode = onmt::Tokenizer::Mode::None;
+  options.no_substitution = true;
+  options.spacer_annotate = true;
+
+  auto* subword_encoder = new onmt::SentencePiece(model_path, nbest_size, alpha);
+  if (!vocabulary_path.empty())
+    subword_encoder->load_vocabulary(vocabulary_path, vocabulary_threshold, &options);
+
+  return new onmt::Tokenizer(options,
+                             std::shared_ptr<const onmt::SubwordEncoder>(subword_encoder));
+}
+
+class SentencePieceTokenizerWrapper : public TokenizerWrapper
+{
+public:
+  SentencePieceTokenizerWrapper(const std::string& model_path,
+                                const std::string& vocabulary_path,
+                                int vocabulary_threshold,
+                                int nbest_size,
+                                float alpha)
+    : TokenizerWrapper(build_sp_tokenizer(model_path,
+                                          vocabulary_path,
+                                          vocabulary_threshold,
+                                          nbest_size,
+                                          alpha))
+  {
+  }
 };
 
 class SubwordLearnerWrapper
@@ -620,6 +658,15 @@ PYBIND11_MODULE(_ext, m)
          py::arg("output_path"))
     .def("__copy__", copy<TokenizerWrapper>)
     .def("__deepcopy__", deepcopy<TokenizerWrapper>)
+    ;
+
+  py::class_<SentencePieceTokenizerWrapper, TokenizerWrapper>(m, "SentencePieceTokenizer")
+    .def(py::init<const std::string&, const std::string&, int, int, float>(),
+         py::arg("model_path"),
+         py::arg("vocabulary_path")="",
+         py::arg("vocabulary_threshold")=0,
+         py::arg("nbest_size")=0,
+         py::arg("alpha")=0.1)
     ;
 
   py::class_<SubwordLearnerWrapper>(m, "SubwordLearner")

--- a/bindings/python/test/test.py
+++ b/bindings/python/test/test.py
@@ -111,6 +111,12 @@ def test_segment_alphabet():
     tokens, _ = tokenizer.tokenize("測試 abc")
     assert tokens == ["測試", "abc"]
 
+def test_sp_tokenizer():
+    sp_model_path = os.path.join(_DATA_DIR, "sp-models", "wmtende.model")
+    tokenizer = pyonmttok.SentencePieceTokenizer(sp_model_path)
+    assert isinstance(tokenizer, pyonmttok.Tokenizer)
+    assert tokenizer.tokenize("Hello")[0] == ["▁H", "ello"]
+
 def test_sp_with_vocabulary(tmpdir):
     sp_model_path = os.path.join(_DATA_DIR, "sp-models", "wmtende.model")
     vocab_path = str(tmpdir.join("vocab.txt"))


### PR DESCRIPTION
This helper class should make it easy to create a tokenizer that is fully compatible with SentencePiece. In particular, the user does not need to think about the tokenization mode or other options that are not relevant to SentencePiece.