### PR TITLE
Update ICU to a newer version in Python wheels

### DIFF
--- a/bindings/python/tools/prepare_build_environment.sh
+++ b/bindings/python/tools/prepare_build_environment.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 
 ROOT_DIR=$PWD
-ICU_VERSION=${ICU_VERSION:-64.2}
+ICU_VERSION=${ICU_VERSION:-66.1}
 
 # Install ICU.
 curl -L -O https://github.com/unicode-org/icu/releases/download/release-${ICU_VERSION/./-}/icu4c-${ICU_VERSION/./_}-src.tgz


### PR DESCRIPTION
More recent ICU versions are available but the GCC version in manylinux1 is too old to compile them.