### PR TITLE
Check tokenization mode when enabling case_markup

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -88,7 +88,7 @@ Hello world !
 
 ### `case_markup` (boolean, default: `false`)
 
-Lowercase text input and inject case markups as additional tokens. This option also enables `segment_case`.
+Lowercase text input and inject case markups as additional tokens. This option also enables `segment_case` and is not compatible with the "none" and "space" tokenization modes.
 
 ```bash
 $ echo "Hello world!" | cli/tokenize --case_markup

--- a/src/Tokenizer.cc
+++ b/src/Tokenizer.cc
@@ -107,7 +107,12 @@ namespace onmt
     if (joiner.empty())
       joiner = joiner_marker;
     if (case_markup)
+    {
+      if (mode == Tokenizer::Mode::None || mode == Tokenizer::Mode::Space)
+        throw std::invalid_argument("case_markup also enables segment_case which is not "
+                                    "compatible with 'none' and 'space' tokenization modes");
       segment_case = true;
+    }
 
     // Check options consistency.
     if (case_feature && case_markup)


### PR DESCRIPTION
`case_markup` is currently not compatible with "none" and "space" tokenization modes.