### PR TITLE
Add lang argument and apply locale-dependent recasing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ else()
 endif()
 
 if(NOT DEFINED ICU_INCLUDE_DIRS OR NOT DEFINED ICU_LIBRARIES)
-  find_package(ICU REQUIRED)
+  find_package(ICU REQUIRED COMPONENTS uc data)
 endif()
 
 set(INCLUDE_DIRECTORIES

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -42,6 +42,7 @@ pip install pyonmttok
 tokenizer = pyonmttok.Tokenizer(
     mode: str,
     *,
+    lang: str = "",
     bpe_model_path: str = "",
     bpe_dropout: float = 0,
     vocabulary_path: str = "",

--- a/bindings/python/pyonmttok/Python.cc
+++ b/bindings/python/pyonmttok/Python.cc
@@ -40,6 +40,7 @@ public:
   }
 
   TokenizerWrapper(const std::string& mode,
+                   const std::string& lang,
                    const std::string& bpe_model_path,
                    const std::string& bpe_vocab_path,
                    int bpe_vocab_threshold,
@@ -82,6 +83,7 @@ public:
 
     onmt::Tokenizer::Options options;
     options.mode = onmt::Tokenizer::str_to_mode(mode);
+    options.lang = lang;
     options.no_substitution = no_substitution;
     options.case_feature = case_feature;
     options.case_markup = case_markup;
@@ -114,6 +116,7 @@ public:
     const auto& options = _tokenizer->get_options();
     return py::dict(
       "mode"_a=onmt::Tokenizer::mode_to_str(options.mode),
+      "lang"_a=options.lang,
       "no_substitution"_a=options.no_substitution,
       "case_feature"_a=options.case_feature,
       "case_markup"_a=options.case_markup,
@@ -566,9 +569,10 @@ PYBIND11_MODULE(_ext, m)
 
   py::class_<TokenizerWrapper>(m, "Tokenizer")
     .def(py::init<const TokenizerWrapper&>(), py::arg("tokenizer"))
-    .def(py::init<const std::string&, const std::string&, const std::string&, int, float, std::string, int, const std::string&, int, float, const std::string&, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, const py::object&>(),
+    .def(py::init<const std::string&, const std::string&, const std::string&, const std::string&, int, float, std::string, int, const std::string&, int, float, const std::string&, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, const py::object&>(),
          py::arg("mode"),
          py::kw_only(),
+         py::arg("lang")="",
          py::arg("bpe_model_path")="",
          py::arg("bpe_vocab_path")="",  // Keep for backward compatibility.
          py::arg("bpe_vocab_threshold")=50,  // Keep for backward compatibility.

--- a/bindings/python/test/test.py
+++ b/bindings/python/test/test.py
@@ -43,6 +43,10 @@ def test_invalid_mode():
     with pytest.raises(ValueError):
         pyonmttok.Tokenizer("xxx")
 
+def test_invalid_lang():
+    with pytest.raises(ValueError, match="ISO"):
+        pyonmttok.Tokenizer("conservative", lang="xxx")
+
 def test_invalid_sentencepiece_model():
     with pytest.raises(ValueError):
         pyonmttok.Tokenizer("none", sp_model_path="xxx")

--- a/cli/detokenize.cc
+++ b/cli/detokenize.cc
@@ -9,6 +9,8 @@ int main(int argc, char* argv[])
   cxxopts::Options cmd_options("detokenize");
   cmd_options.add_options()
     ("h,help", "Show this help")
+    ("lang", "ISO language code of the input",
+     cxxopts::value<std::string>()->default_value(""))
     ("joiner", "Set the joiner token",
      cxxopts::value<std::string>()->default_value(onmt::Tokenizer::joiner_marker))
     ("spacer_annotate", "Run spacer detokenization instead of joiner detokenization",
@@ -26,6 +28,7 @@ int main(int argc, char* argv[])
   }
 
   onmt::Tokenizer::Options options;
+  options.lang = vm["lang"].as<std::string>();
   options.case_feature = vm["case_feature"].as<bool>();
   options.spacer_annotate = vm["spacer_annotate"].as<bool>();
   options.joiner = vm["joiner"].as<std::string>();

--- a/cli/tokenization_args.h
+++ b/cli/tokenization_args.h
@@ -9,6 +9,8 @@ inline void add_tokenization_options(cxxopts::Options& options)
   options.add_options("General tokenization")
     ("m,mode", "Set the tokenization mode (can be: conservative, aggressive, char, space, none)",
      cxxopts::value<std::string>()->default_value("conservative"))
+    ("lang", "ISO language code of the input",
+     cxxopts::value<std::string>()->default_value(""))
     ("no_substitution", "Do not replace special characters found in the input text",
      cxxopts::value<bool>()->default_value("false"))
     ;
@@ -58,6 +60,7 @@ inline onmt::Tokenizer::Options build_tokenization_options(const cxxopts::ParseR
 {
   onmt::Tokenizer::Options options;
   options.mode = onmt::Tokenizer::str_to_mode(args["mode"].as<std::string>());
+  options.lang = args["lang"].as<std::string>();
   options.no_substitution = args["no_substitution"].as<bool>();
   options.case_feature = args["case_feature"].as<bool>();
   options.case_markup = args["case_markup"].as<bool>();

--- a/docs/options.md
+++ b/docs/options.md
@@ -137,6 +137,18 @@ $ echo "A-BC/D" | cli/tokenize --case_markup --soft_case_regions
 ｟mrk_begin_case_region_U｠ a- bc / d ｟mrk_end_case_region_U｠
 ```
 
+### `lang` (string, default: `""`)
+
+[ISO language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) of the text passed to the tokenizer. When set, the tokenizer may enable language specific rules for example when recasing tokens during detokenization:
+
+```bash
+$ echo "｟mrk_case_modifier_C｠ ijssel" | cli/detokenize --lang nl
+IJssel
+
+$ echo "｟mrk_begin_case_region_U｠ γύρισε σπίτι ｟mrk_end_case_region_U｠" | cli/detokenize --lang el
+ΓΥΡΙΣΕ ΣΠΙΤΙ
+```
+
 ## Subword encoding
 
 ### `bpe_model_path` (string, default: `""`)

--- a/docs/options.md
+++ b/docs/options.md
@@ -139,14 +139,27 @@ $ echo "A-BC/D" | cli/tokenize --case_markup --soft_case_regions
 
 ### `lang` (string, default: `""`)
 
-[ISO language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) of the text passed to the tokenizer. When set, the tokenizer may enable language specific rules for example when recasing tokens during detokenization:
+[ISO language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) of the text passed to the tokenizer. When set, the tokenizer may enable language-specific rules to improve the tokenization or detokenization correctness. For example, we use the [ICU library](http://site.icu-project.org/) to enable [language-specific case mappings](https://unicode-org.github.io/icu/userguide/transforms/casemappings.html#full-language-specific-case-mapping) such as the following:
+
+* In Dutch, the "ij" digraph becomes "IJ" even with capitalization:
 
 ```bash
 $ echo "｟mrk_case_modifier_C｠ ijssel" | cli/detokenize --lang nl
 IJssel
+```
 
+* In Greek, most vowels loose their accent when the whole word is in uppercase:
+
+```bash
 $ echo "｟mrk_begin_case_region_U｠ γύρισε σπίτι ｟mrk_end_case_region_U｠" | cli/detokenize --lang el
 ΓΥΡΙΣΕ ΣΠΙΤΙ
+```
+
+* In Greek, the lowercase version of sigma "Σ" depends on the context:
+
+```bash
+$ echo "ΣΙΓΜΑ ΤΕΛΙΚΟΣ" | cli/tokenize --lang el --case_markup --soft_case_regions
+｟mrk_begin_case_region_U｠ σιγμα τελικος ｟mrk_end_case_region_U｠
 ```
 
 ## Subword encoding

--- a/include/onmt/Token.h
+++ b/include/onmt/Token.h
@@ -55,7 +55,6 @@ namespace onmt
 
     bool is_placeholder() const;
     size_t unicode_length() const;
-    void lowercase();
 
     void append_feature(std::string feature)
     {

--- a/include/onmt/Tokenizer.h
+++ b/include/onmt/Tokenizer.h
@@ -34,6 +34,7 @@ namespace onmt
     struct Options
     {
       Mode mode = Mode::Conservative;
+      std::string lang;
       bool no_substitution = false;
       bool case_feature = false;
       bool case_markup = false;

--- a/include/onmt/unicode/Unicode.h
+++ b/include/onmt/unicode/Unicode.h
@@ -43,6 +43,8 @@ namespace onmt
     OPENNMTTOKENIZER_EXPORT code_point_t get_upper(code_point_t u);
     OPENNMTTOKENIZER_EXPORT code_point_t get_lower(code_point_t u);
 
+    OPENNMTTOKENIZER_EXPORT bool is_valid_language(const char* language);
+
     OPENNMTTOKENIZER_EXPORT int get_script_code(const char* script_name);
     OPENNMTTOKENIZER_EXPORT const char* get_script_name(int script_code);
     OPENNMTTOKENIZER_EXPORT int get_script(code_point_t c, int previous_script = -1);

--- a/src/Casing.cc
+++ b/src/Casing.cc
@@ -90,7 +90,6 @@ namespace onmt
       throw std::invalid_argument("Can't restore mixed casing");
 
     std::string new_token;
-    new_token.reserve(token.size());
 
     if (!lang.empty())
     {
@@ -105,6 +104,7 @@ namespace onmt
       return new_token;
     }
 
+    new_token.reserve(token.size());
     for (const auto& c : unicode::get_characters_info(token))
     {
       if (new_token.empty() || casing == Casing::Uppercase)

--- a/src/Casing.h
+++ b/src/Casing.h
@@ -11,7 +11,9 @@ namespace onmt
                        size_t letter_index);
 
   std::pair<std::string, Casing> lowercase_token(const std::string& token);
-  std::string restore_token_casing(const std::string& token, Casing casing);
+  std::string restore_token_casing(const std::string& token,
+                                   Casing casing,
+                                   const std::string& lang = "");
 
   char casing_to_char(Casing type);
   Casing char_to_casing(char feature);

--- a/src/Casing.h
+++ b/src/Casing.h
@@ -10,7 +10,8 @@ namespace onmt
                        unicode::CaseType letter_case,
                        size_t letter_index);
 
-  std::pair<std::string, Casing> lowercase_token(const std::string& token);
+  std::pair<std::string, Casing> lowercase_token(const std::string& token,
+                                                 const std::string& lang = "");
   std::string restore_token_casing(const std::string& token,
                                    Casing casing,
                                    const std::string& lang = "");

--- a/src/Token.cc
+++ b/src/Token.cc
@@ -1,9 +1,6 @@
 #include "onmt/Token.h"
 
-#include <tuple>
-
 #include "onmt/unicode/Unicode.h"
-#include "Casing.h"
 #include "Utils.h"
 
 namespace onmt
@@ -15,12 +12,6 @@ namespace onmt
 
   size_t Token::unicode_length() const {
     return unicode::utf8len(surface);
-  }
-
-  void Token::lowercase() {
-    if (is_placeholder())
-      return;
-    std::tie(surface, casing) = lowercase_token(surface);
   }
 
 }

--- a/src/Tokenizer.cc
+++ b/src/Tokenizer.cc
@@ -1,7 +1,5 @@
 #include "onmt/Tokenizer.h"
 
-#include <unicode/locid.h>
-
 #include "onmt/BPE.h"
 #include "onmt/SentencePiece.h"
 #include "onmt/unicode/Unicode.h"
@@ -134,7 +132,7 @@ namespace onmt
         throw std::invalid_argument("invalid Unicode script: " + alphabet);
     }
 
-    if (!lang.empty() && icu::Locale(lang.c_str()).isBogus())
+    if (!lang.empty() && !unicode::is_valid_language(lang.c_str()))
       throw std::invalid_argument("lang argument should be a valid ISO language code");
   }
 

--- a/src/Tokenizer.cc
+++ b/src/Tokenizer.cc
@@ -1,5 +1,7 @@
 #include "onmt/Tokenizer.h"
 
+#include <unicode/locid.h>
+
 #include "onmt/BPE.h"
 #include "onmt/SentencePiece.h"
 #include "onmt/unicode/Unicode.h"
@@ -131,6 +133,9 @@ namespace onmt
       if (!add_alphabet_to_segment(alphabet))
         throw std::invalid_argument("invalid Unicode script: " + alphabet);
     }
+
+    if (!lang.empty() && icu::Locale(lang.c_str()).isBogus())
+      throw std::invalid_argument("lang argument should be a valid ISO language code");
   }
 
   bool Tokenizer::Options::add_alphabet_to_segment(const std::string& alphabet)
@@ -311,7 +316,7 @@ namespace onmt
       if (!token.is_placeholder())
       {
         if (token.casing != Casing::None && token.casing != Casing::Lowercase)
-          prep_word = restore_token_casing(prep_word, token.casing);
+          prep_word = restore_token_casing(prep_word, token.casing, _options.lang);
         unescape_characters(prep_word);
       }
 

--- a/src/Tokenizer.cc
+++ b/src/Tokenizer.cc
@@ -506,7 +506,10 @@ namespace onmt
     if (_options.case_markup || _options.case_feature)
     {
       for (auto& token : annotated_tokens)
-        token.lowercase();
+      {
+        if (!token.is_placeholder())
+          std::tie(token.surface, token.casing) = lowercase_token(token.surface, _options.lang);
+      }
     }
 
     if (_subword_encoder)

--- a/src/unicode/Unicode.cc
+++ b/src/unicode/Unicode.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstring>
 
+#include <unicode/locid.h>
 #include <unicode/uchar.h>
 #include <unicode/unistr.h>
 #include <unicode/uscript.h>
@@ -247,6 +248,18 @@ namespace onmt
         });
 
       return chars;
+    }
+
+    bool is_valid_language(const char* language)
+    {
+      for (const char* const* available_languages = icu::Locale::getISOLanguages();
+           *available_languages;
+           ++available_languages)
+      {
+        if (strcmp(*available_languages, language) == 0)
+          return true;
+      }
+      return false;
     }
 
     // The functions below are made backward compatible with the Kangxi and Kanbun script names

--- a/test/test.cc
+++ b/test/test.cc
@@ -474,7 +474,7 @@ TEST(TokenizerTest, CaseMarkupWithLocaleEl) {
   options.case_markup = true;
   options.lang = "el";
   Tokenizer tokenizer(options);
-  test_tok(tokenizer, "ΣIΓΜΑ", "｟mrk_begin_case_region_U｠ σiγμα ｟mrk_end_case_region_U｠");
+  test_tok(tokenizer, "ΣΙΓΜΑ", "｟mrk_begin_case_region_U｠ σιγμα ｟mrk_end_case_region_U｠");
   test_tok(tokenizer, "ΤΕΛΙΚΟΣ", "｟mrk_begin_case_region_U｠ τελικος ｟mrk_end_case_region_U｠");
   test_detok(tokenizer,
              "｟mrk_begin_case_region_U｠ την άνοιξη , απρίλιο ή μάιο , θα καταναλώσω μεγαλύτερες ποσότητες πρωτεΐνης ｟mrk_end_case_region_U｠",

--- a/test/test.cc
+++ b/test/test.cc
@@ -469,6 +469,22 @@ TEST(TokenizerTest, CaseMarkupDetokNestedMarkers) {
              "｟mrk_begin_case_region_U｠ hello ｟mrk_case_modifier_C｠ ｟mrk_end_case_region_U｠ world", "HELLO world");
 }
 
+TEST(TokenizerTest, CaseMarkupWithLocaleEl) {
+  Tokenizer::Options options;
+  options.lang = "el";
+  Tokenizer tokenizer(options);
+  test_detok(tokenizer,
+             "｟mrk_begin_case_region_U｠ μετα απο αυτο , γύρισε σπίτι ｟mrk_end_case_region_U｠",
+             "ΜΕΤΑ ΑΠΟ ΑΥΤΟ , ΓΥΡΙΣΕ ΣΠΙΤΙ");
+}
+
+TEST(TokenizerTest, CaseMarkupWithLocaleNl) {
+  Tokenizer::Options options;
+  options.lang = "nl";
+  Tokenizer tokenizer(options);
+  test_detok(tokenizer, "｟mrk_case_modifier_C｠ ijssel", "IJssel");
+}
+
 TEST(TokenizerTest, SegmentCase) {
   Tokenizer tokenizer(Tokenizer::Mode::Conservative,
                       Tokenizer::Flags::CaseFeature | Tokenizer::Flags::JoinerAnnotate | Tokenizer::Flags::SegmentCase);

--- a/test/test.cc
+++ b/test/test.cc
@@ -474,8 +474,8 @@ TEST(TokenizerTest, CaseMarkupWithLocaleEl) {
   options.lang = "el";
   Tokenizer tokenizer(options);
   test_detok(tokenizer,
-             "｟mrk_begin_case_region_U｠ μετα απο αυτο , γύρισε σπίτι ｟mrk_end_case_region_U｠",
-             "ΜΕΤΑ ΑΠΟ ΑΥΤΟ , ΓΥΡΙΣΕ ΣΠΙΤΙ");
+             "｟mrk_begin_case_region_U｠ την άνοιξη , απρίλιο ή μάιο , θα καταναλώσω μεγαλύτερες ποσότητες πρωτεΐνης ｟mrk_end_case_region_U｠",
+             "ΤΗΝ ΑΝΟΙΞΗ , ΑΠΡΙΛΙΟ Ή ΜΑΪΟ , ΘΑ ΚΑΤΑΝΑΛΩΣΩ ΜΕΓΑΛΥΤΕΡΕΣ ΠΟΣΟΤΗΤΕΣ ΠΡΩΤΕΪΝΗΣ");
 }
 
 TEST(TokenizerTest, CaseMarkupWithLocaleNl) {

--- a/test/test.cc
+++ b/test/test.cc
@@ -472,10 +472,12 @@ TEST(TokenizerTest, CaseMarkupDetokNestedMarkers) {
 TEST(TokenizerTest, CaseMarkupWithLocaleEl) {
   Tokenizer::Options options;
   options.case_markup = true;
+  options.soft_case_regions = true;
   options.lang = "el";
   Tokenizer tokenizer(options);
-  test_tok(tokenizer, "ΣΙΓΜΑ", "｟mrk_begin_case_region_U｠ σιγμα ｟mrk_end_case_region_U｠");
-  test_tok(tokenizer, "ΤΕΛΙΚΟΣ", "｟mrk_begin_case_region_U｠ τελικος ｟mrk_end_case_region_U｠");
+  test_tok(tokenizer,
+           "ΣΙΓΜΑ ΤΕΛΙΚΟΣ",
+           "｟mrk_begin_case_region_U｠ σιγμα τελικος ｟mrk_end_case_region_U｠");
   test_detok(tokenizer,
              "｟mrk_begin_case_region_U｠ την άνοιξη , απρίλιο ή μάιο , θα καταναλώσω μεγαλύτερες ποσότητες πρωτεΐνης ｟mrk_end_case_region_U｠",
              "ΤΗΝ ΑΝΟΙΞΗ , ΑΠΡΙΛΙΟ Ή ΜΑΪΟ , ΘΑ ΚΑΤΑΝΑΛΩΣΩ ΜΕΓΑΛΥΤΕΡΕΣ ΠΟΣΟΤΗΤΕΣ ΠΡΩΤΕΪΝΗΣ");

--- a/test/test.cc
+++ b/test/test.cc
@@ -471,8 +471,11 @@ TEST(TokenizerTest, CaseMarkupDetokNestedMarkers) {
 
 TEST(TokenizerTest, CaseMarkupWithLocaleEl) {
   Tokenizer::Options options;
+  options.case_markup = true;
   options.lang = "el";
   Tokenizer tokenizer(options);
+  test_tok(tokenizer, "ΣIΓΜΑ", "｟mrk_begin_case_region_U｠ σiγμα ｟mrk_end_case_region_U｠");
+  test_tok(tokenizer, "ΤΕΛΙΚΟΣ", "｟mrk_begin_case_region_U｠ τελικος ｟mrk_end_case_region_U｠");
   test_detok(tokenizer,
              "｟mrk_begin_case_region_U｠ την άνοιξη , απρίλιο ή μάιο , θα καταναλώσω μεγαλύτερες ποσότητες πρωτεΐνης ｟mrk_end_case_region_U｠",
              "ΤΗΝ ΑΝΟΙΞΗ , ΑΠΡΙΛΙΟ Ή ΜΑΪΟ , ΘΑ ΚΑΤΑΝΑΛΩΣΩ ΜΕΓΑΛΥΤΕΡΕΣ ΠΟΣΟΤΗΤΕΣ ΠΡΩΤΕΪΝΗΣ");
@@ -480,6 +483,7 @@ TEST(TokenizerTest, CaseMarkupWithLocaleEl) {
 
 TEST(TokenizerTest, CaseMarkupWithLocaleNl) {
   Tokenizer::Options options;
+  options.case_markup = true;
   options.lang = "nl";
   Tokenizer tokenizer(options);
   test_detok(tokenizer, "｟mrk_case_modifier_C｠ ijssel", "IJssel");


### PR DESCRIPTION
@panosk What do you think this? When the `lang` argument is set, we apply the locale-dependent uppercasing and titlecasing as provided by ICU (see the examples in the documentation below).

Related to #239.