### PR TITLE
Fix divergence with SentencePiece for detached leading spacers

### DIFF
--- a/src/SubwordEncoder.cc
+++ b/src/SubwordEncoder.cc
@@ -80,11 +80,14 @@ namespace onmt
 
   void SubwordEncoder::propagate_token_properties(const Token& token, std::vector<Token>& tokens)
   {
-    tokens.front().join_left = token.join_left;
-    tokens.back().join_right = token.join_right;
+    auto& first = tokens.front();
+    auto& last = tokens.back();
 
-    tokens.front().preserve = token.join_left && token.preserve;
-    tokens.back().preserve = token.join_right && token.preserve;
+    first.join_left = token.join_left;
+    last.join_right = token.join_right;
+
+    first.preserve = (token.join_left && token.preserve) || (first.preserve && first.spacer);
+    last.preserve = token.join_right && token.preserve;
 
     if (token.casing != Casing::None)
     {

--- a/test/test.cc
+++ b/test/test.cc
@@ -831,6 +831,14 @@ TEST(TokenizerTest, SentencePieceAlt) {
                      "▁Ba m ford ▁is ▁appealing ▁the ▁sentence ▁and ▁has ▁been ▁granted ▁bail ▁of ▁ 50,000 ▁ba ht .");
 }
 
+TEST(TokenizerTest, SentencePieceLeadingSpacer) {
+  Tokenizer tokenizer(Tokenizer::Mode::None, Tokenizer::Flags::SentencePieceModel,
+                      get_data("sp-models/wmtende.model"));
+  test_tok_and_detok(tokenizer,
+                     "Experts say violence that left 14 adults and seven children dead is nothing more than random chance, not a sign of growing violence in America.",
+                     "▁ Expert s ▁say ▁violence ▁that ▁left ▁14 ▁adults ▁and ▁seven ▁children ▁dead ▁is ▁nothing ▁more ▁than ▁random ▁chance , ▁not ▁a ▁sign ▁of ▁growing ▁violence ▁in ▁America .");
+}
+
 TEST(TokenizerTest, SentencePieceWithJoiners) {
   Tokenizer tokenizer(Tokenizer::Mode::None,
                       Tokenizer::Flags::JoinerAnnotate | Tokenizer::Flags::SentencePieceModel,


### PR DESCRIPTION
Bug introduced in https://github.com/OpenNMT/Tokenizer/commit/520d034d6cd94f7a66360491a17cf1596a8e8fef.