### PR TITLE
Fix handling of detached spacers for single SentencePiece subword

### DIFF
--- a/src/SubwordEncoder.cc
+++ b/src/SubwordEncoder.cc
@@ -87,7 +87,8 @@ namespace onmt
     last.join_right = token.join_right;
 
     first.preserve = (token.join_left && token.preserve) || (first.preserve && first.spacer);
-    last.preserve = token.join_right && token.preserve;
+    if (tokens.size() > 1)
+      last.preserve = token.join_right && token.preserve;
 
     if (token.casing != Casing::None)
     {

--- a/test/test.cc
+++ b/test/test.cc
@@ -834,9 +834,8 @@ TEST(TokenizerTest, SentencePieceAlt) {
 TEST(TokenizerTest, SentencePieceLeadingSpacer) {
   Tokenizer tokenizer(Tokenizer::Mode::None, Tokenizer::Flags::SentencePieceModel,
                       get_data("sp-models/wmtende.model"));
-  test_tok_and_detok(tokenizer,
-                     "Experts say violence that left 14 adults and seven children dead is nothing more than random chance, not a sign of growing violence in America.",
-                     "▁ Expert s ▁say ▁violence ▁that ▁left ▁14 ▁adults ▁and ▁seven ▁children ▁dead ▁is ▁nothing ▁more ▁than ▁random ▁chance , ▁not ▁a ▁sign ▁of ▁growing ▁violence ▁in ▁America .");
+  test_tok_and_detok(tokenizer, "Experts", "▁ Expert s");
+  test_tok_and_detok(tokenizer, "Expert", "▁ Expert");
 }
 
 TEST(TokenizerTest, SentencePieceWithJoiners) {


### PR DESCRIPTION
This is the same issue as https://github.com/OpenNMT/Tokenizer/commit/4056836634d1c827798b7658b6a5325ea187bafe but it happens when SentencePiece outputs a single subword. This case is rare unless SentencePiece is used as a subtokenizer.