### PR TITLE
Fix casing resolution when some letters do not have case information

### DIFF
--- a/src/Casing.cc
+++ b/src/Casing.cc
@@ -26,13 +26,21 @@ namespace onmt
     switch (current_casing)
     {
     case Casing::None:
-      if (letter_case == unicode::CaseType::Lower)
-        return Casing::Lowercase;
-      if (letter_case == unicode::CaseType::Upper)
-        return Casing::Capitalized;
+      if (letter_index == 0)
+      {
+        if (letter_case == unicode::CaseType::Lower)
+          return Casing::Lowercase;
+        if (letter_case == unicode::CaseType::Upper)
+          return Casing::Capitalized;
+      }
+      else
+      {
+        if (letter_case != unicode::CaseType::None)
+          return Casing::Mixed;
+      }
       break;
     case Casing::Lowercase:
-      if (letter_case == unicode::CaseType::Upper)
+      if (letter_case != unicode::CaseType::Lower)
         return Casing::Mixed;
       break;
     case Casing::Capitalized:
@@ -45,12 +53,12 @@ namespace onmt
       }
       else
       {
-        if (letter_case == unicode::CaseType::Upper)
+        if (letter_case != unicode::CaseType::Lower)
           return Casing::Mixed;
       }
       break;
     case Casing::Uppercase:
-      if (letter_case == unicode::CaseType::Lower)
+      if (letter_case != unicode::CaseType::Upper)
         return Casing::Mixed;
       break;
     default:

--- a/test/test.cc
+++ b/test/test.cc
@@ -439,6 +439,14 @@ TEST(TokenizerTest, CaseMarkupWithBPE) {
                      "BONJOUR monde", "｟mrk_begin_case_region_U｠ bon￭ j￭ our ｟mrk_end_case_region_U｠ mon￭ de");
 }
 
+TEST(TokenizerTest, CaseMarkupWithMixedScripts) {
+  Tokenizer tokenizer(Tokenizer::Mode::Conservative,
+                      Tokenizer::Flags::CaseMarkup | Tokenizer::Flags::JoinerAnnotate);
+  test_tok_and_detok(tokenizer,
+                     "「我々は、うまくやっていることを証明した」とヒョンCEOは話す。",
+                     "「￭ 我々は ￭、￭ うまくやっていることを証明した ￭」￭ とヒョン￭ ｟mrk_begin_case_region_U｠ ceo￭ ｟mrk_end_case_region_U｠ は話す ￭。");
+}
+
 TEST(TokenizerTest, CaseMarkupDetokWithPlaceholders) {
   Tokenizer tokenizer(Tokenizer::Mode::Conservative, Tokenizer::Flags::CaseMarkup);
   test_detok(tokenizer, "｟mrk_case_modifier_C｠ ｟abc｠", "｟abc｠");


### PR DESCRIPTION
The code did not consider that letters could not have any case information. This caused incorrect casing resolution when letters with and without case information are mixed.

This issue can happen when the sentence contains multiple scripts, e.g. Hiragana and Latin characters, so using the option `segment_alphabet_change` can also prevent this bug.