### PR TITLE
Upgrade the Python wheels build environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,8 @@ jobs:
           output-dir: wheelhouse
         env:
           CIBW_BEFORE_ALL: bindings/python/tools/prepare_build_environment.sh
-          CIBW_BEFORE_BUILD: pip install pybind11==2.6.2
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
+          CIBW_BEFORE_BUILD: pip install pybind11==2.7.1
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
           CIBW_TEST_COMMAND: pytest {project}/bindings/python/test/test.py
           CIBW_TEST_REQUIRES: pytest
           CIBW_ARCHS: auto64

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -66,7 +66,8 @@ tokenizer = pyonmttok.Tokenizer(
     segment_case: bool = False,
     segment_numbers: bool = False,
     segment_alphabet_change: bool = False,
-    segment_alphabet: Optional[List[str]] = None)
+    segment_alphabet: Optional[List[str]] = None,
+)
 
 # SentencePiece-compatible tokenizer.
 tokenizer = pyonmttok.SentencePieceTokenizer(
@@ -90,8 +91,8 @@ See the [documentation](https://github.com/OpenNMT/Tokenizer/blob/master/docs/op
 
 ```python
 # By default, tokenize returns the tokens and features.
-# When training=False, subword regularization such as BPE dropout is disabled.
 # When as_token_objects=True, the method returns Token objects (see below).
+# When training=False, subword regularization such as BPE dropout is disabled.
 tokenizer.tokenize(
     text: str,
     as_token_objects: bool = False,
@@ -114,7 +115,7 @@ tokenizer.tokenize_file(
 # The detokenize method converts a list of tokens back to a string.
 tokenizer.detokenize(
     tokens: List[str],
-    features: Optional[List[List[str]]] = None
+    features: Optional[List[List[str]]] = None,
 ) -> str
 tokenizer.detokenize(tokens: List[pyonmttok.Token]) -> str
 
@@ -125,8 +126,8 @@ tokenizer.detokenize(tokens: List[pyonmttok.Token]) -> str
 # Set unicode_ranges=True to return ranges over Unicode characters instead of bytes.
 tokenizer.detokenize_with_ranges(
     tokens: Union[List[str], List[pyonmttok.Token]],
-    merge_ranges: bool = True,
-    unicode_ranges: bool = True
+    merge_ranges: bool = False,
+    unicode_ranges: bool = False,
 ) -> Tuple[str, Dict[int, Tuple[int, int]]]
 
 # Detokenize a file.
@@ -179,14 +180,16 @@ learner = pyonmttok.BPELearner(
     tokenizer: Optional[pyonmttok.Tokenizer] = None,  # Defaults to tokenization mode "space".
     symbols: int = 10000,
     min_frequency: int = 2,
-    total_symbols: bool = False)
+    total_symbols: bool = False,
+)
 
 # See https://github.com/google/sentencepiece/blob/master/src/spm_train_main.cc
 # for available training options.
 learner = pyonmttok.SentencePieceLearner(
     tokenizer: Optional[pyonmttok.Tokenizer] = None,  # Defaults to tokenization mode "none".
     keep_vocab: bool = False,  # Keep the generated vocabulary (model_path will act like model_prefix in spm_train)
-    **training_options)
+    **training_options,
+)
 
 learner.ingest(text: str)
 learner.ingest_file(path: str)
@@ -255,7 +258,7 @@ tokenizer.serialize_tokens(
 # Deserialize strings into Token objects.
 tokenizer.deserialize_tokens(
     tokens: List[str],
-    features: Optional[List[List[str]]] = None
+    features: Optional[List[List[str]]] = None,
 ) -> List[pyonmttok.Token]
 ```
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -12,6 +12,7 @@ pip install pyonmttok
 
 * OS: Linux, macOS
 * Python version: >= 3.5
+* pip version: >= 19.0
 
 **Table of contents**
 
@@ -42,12 +43,12 @@ pip install pyonmttok
 tokenizer = pyonmttok.Tokenizer(
     mode: str,
     *,
-    lang: str = "",
-    bpe_model_path: str = "",
+    lang: Optional[str] = None,
+    bpe_model_path: Optional[str] = None,
     bpe_dropout: float = 0,
-    vocabulary_path: str = "",
+    vocabulary_path: Optional[str] = None,
     vocabulary_threshold: int = 0,
-    sp_model_path: str = "",
+    sp_model_path: Optional[str] = None,
     sp_nbest_size: int = 0,
     sp_alpha: float = 0.1,
     joiner: str = "￭",
@@ -70,7 +71,7 @@ tokenizer = pyonmttok.Tokenizer(
 # SentencePiece-compatible tokenizer.
 tokenizer = pyonmttok.SentencePieceTokenizer(
     model_path: str,
-    vocabulary_path: str = "",
+    vocabulary_path: Optional[str] = None,
     vocabulary_threshold: int = 0,
     nbest_size: int = 0,
     alpha: float = 0.1,
@@ -90,17 +91,12 @@ See the [documentation](https://github.com/OpenNMT/Tokenizer/blob/master/docs/op
 ```python
 # By default, tokenize returns the tokens and features.
 # When training=False, subword regularization such as BPE dropout is disabled.
+# When as_token_objects=True, the method returns Token objects (see below).
 tokenizer.tokenize(
     text: str,
+    as_token_objects: bool = False,
     training: bool = True,
-) -> Tuple[List[str], List[List[str]]]
-
-# The as_token_objects flag can alternatively return Token objects (see below).
-tokenizer.tokenize(
-    text: str,
-    as_token_objects: bool = True,
-    training: bool = True,
-) -> List[pyonmttok.Token]
+) -> Union[Tuple[List[str], Optional[List[List[str]]]], List[pyonmttok.Token]]
 
 # Tokenize a file.
 tokenizer.tokenize_file(
@@ -117,9 +113,10 @@ tokenizer.tokenize_file(
 ```python
 # The detokenize method converts a list of tokens back to a string.
 tokenizer.detokenize(
-    tokens: Union[List[str], List[pyonmttok.Token]],
+    tokens: List[str],
     features: Optional[List[List[str]]] = None
 ) -> str
+tokenizer.detokenize(tokens: List[pyonmttok.Token]) -> str
 
 # The detokenize_with_ranges method also returns a dictionary mapping a token
 # index to a range in the detokenized text.
@@ -130,7 +127,7 @@ tokenizer.detokenize_with_ranges(
     tokens: Union[List[str], List[pyonmttok.Token]],
     merge_ranges: bool = True,
     unicode_ranges: bool = True
-) -> Tuple[str, Dict[int, Pair[int, int]]]
+) -> Tuple[str, Dict[int, Tuple[int, int]]]
 
 # Detokenize a file.
 tokenizer.detokenize_file(input_path: str, output_path: str)
@@ -251,7 +248,9 @@ The `Tokenizer` instances provide methods to serialize or deserialize `Token` ob
 
 ```python
 # Serialize Token objects to strings that can be saved on disk.
-tokenizer.serialize_tokens(tokens: List[pyonmttok.Token]) -> Tuple[List[str], List[List[str]]]
+tokenizer.serialize_tokens(
+    tokens: List[pyonmttok.Token],
+) -> Tuple[List[str], Optional[List[List[str]]]]
 
 # Deserialize strings into Token objects.
 tokenizer.deserialize_tokens(

--- a/bindings/python/pyonmttok/Python.cc
+++ b/bindings/python/pyonmttok/Python.cc
@@ -15,23 +15,6 @@
 namespace py = pybind11;
 using namespace pybind11::literals;
 
-static onmt::Ranges to_unicode_ranges(const std::string& text, const onmt::Ranges& ranges)
-{
-  onmt::Ranges unicode_ranges;
-  for (const auto& pair : ranges)
-  {
-    const size_t word_index = pair.first;
-    const onmt::Range& range = pair.second;
-    const std::string prefix(text.c_str(), range.first);
-    const std::string piece(text.c_str() + range.first, range.second - range.first + 1);
-    const size_t prefix_length = onmt::unicode::utf8len(prefix);
-    const size_t piece_length = onmt::unicode::utf8len(piece);
-    unicode_ranges.emplace(word_index,
-                           onmt::Range(prefix_length, prefix_length + piece_length - 1));
-  }
-  return unicode_ranges;
-}
-
 
 class TokenizerWrapper
 {
@@ -190,11 +173,7 @@ public:
                          bool merge_ranges,
                          bool with_unicode_ranges) const
   {
-    onmt::Ranges ranges;
-    std::string text = _tokenizer->detokenize(tokens, ranges, merge_ranges);
-    if (with_unicode_ranges)
-      ranges = to_unicode_ranges(text, ranges);
-    return std::make_pair(std::move(text), std::move(ranges));
+    return detokenize_with_ranges_impl(tokens, merge_ranges, with_unicode_ranges);
   }
 
   std::pair<std::string, onmt::Ranges>
@@ -202,11 +181,7 @@ public:
                          bool merge_ranges,
                          bool with_unicode_ranges) const
   {
-    onmt::Ranges ranges;
-    std::string text = _tokenizer->detokenize(tokens, ranges, merge_ranges);
-    if (with_unicode_ranges)
-      ranges = to_unicode_ranges(text, ranges);
-    return std::make_pair(std::move(text), std::move(ranges));
+    return detokenize_with_ranges_impl(tokens, merge_ranges, with_unicode_ranges);
   }
 
   std::string detokenize(const std::vector<onmt::Token>& tokens) const
@@ -254,6 +229,36 @@ public:
 
 private:
   std::shared_ptr<const onmt::Tokenizer> _tokenizer;
+
+  template <typename T>
+  std::pair<std::string, onmt::Ranges>
+  detokenize_with_ranges_impl(const std::vector<T>& tokens,
+                              bool merge_ranges,
+                              bool with_unicode_ranges) const
+  {
+    onmt::Ranges ranges;
+    std::string text = _tokenizer->detokenize(tokens, ranges, merge_ranges);
+
+    if (with_unicode_ranges)
+    {
+      onmt::Ranges unicode_ranges;
+      for (const auto& pair : ranges)
+      {
+        const size_t word_index = pair.first;
+        const onmt::Range& range = pair.second;
+        const std::string prefix(text.c_str(), range.first);
+        const std::string piece(text.c_str() + range.first, range.second - range.first + 1);
+        const size_t prefix_length = onmt::unicode::utf8len(prefix);
+        const size_t piece_length = onmt::unicode::utf8len(piece);
+        unicode_ranges.emplace(word_index,
+                               onmt::Range(prefix_length, prefix_length + piece_length - 1));
+      }
+      ranges = std::move(unicode_ranges);
+    }
+
+    return std::make_pair(std::move(text), std::move(ranges));
+  }
+
 };
 
 static std::shared_ptr<onmt::Tokenizer>

--- a/bindings/python/pyonmttok/Python.cc
+++ b/bindings/python/pyonmttok/Python.cc
@@ -19,16 +19,6 @@ using namespace pybind11::literals;
 class TokenizerWrapper
 {
 public:
-  TokenizerWrapper(TokenizerWrapper&& other)
-    : _tokenizer(std::move(other._tokenizer))
-  {
-  }
-
-  TokenizerWrapper(const TokenizerWrapper& other)
-    : _tokenizer(other._tokenizer)
-  {
-  }
-
   TokenizerWrapper(std::shared_ptr<const onmt::Tokenizer> tokenizer)
     : _tokenizer(std::move(tokenizer))
   {
@@ -300,7 +290,7 @@ public:
 class SubwordLearnerWrapper
 {
 public:
-  SubwordLearnerWrapper(const TokenizerWrapper* tokenizer,
+  SubwordLearnerWrapper(const std::optional<TokenizerWrapper>& tokenizer,
                         std::unique_ptr<onmt::SubwordLearner> learner)
     : _tokenizer(tokenizer ? tokenizer->get() : learner->get_default_tokenizer())
     , _learner(std::move(learner))
@@ -354,7 +344,7 @@ private:
 class BPELearnerWrapper : public SubwordLearnerWrapper
 {
 public:
-  BPELearnerWrapper(const TokenizerWrapper* tokenizer,
+  BPELearnerWrapper(const std::optional<TokenizerWrapper>& tokenizer,
                     int symbols,
                     int min_frequency,
                     bool total_symbols)
@@ -398,7 +388,7 @@ static std::string create_temp_file()
 class SentencePieceLearnerWrapper : public SubwordLearnerWrapper
 {
 public:
-  SentencePieceLearnerWrapper(const TokenizerWrapper* tokenizer,
+  SentencePieceLearnerWrapper(const std::optional<TokenizerWrapper>& tokenizer,
                               bool keep_vocab,
                               py::kwargs kwargs)
     : SubwordLearnerWrapper(tokenizer,
@@ -692,7 +682,7 @@ PYBIND11_MODULE(_ext, m)
     ;
 
   py::class_<BPELearnerWrapper, SubwordLearnerWrapper>(m, "BPELearner")
-    .def(py::init<const TokenizerWrapper*, int, int, bool>(),
+    .def(py::init<const std::optional<TokenizerWrapper>&, int, int, bool>(),
          py::arg("tokenizer")=py::none(),
          py::arg("symbols")=10000,
          py::arg("min_frequency")=2,
@@ -700,7 +690,7 @@ PYBIND11_MODULE(_ext, m)
     ;
 
   py::class_<SentencePieceLearnerWrapper, SubwordLearnerWrapper>(m, "SentencePieceLearner")
-    .def(py::init<const TokenizerWrapper*, bool, py::kwargs>(),
+    .def(py::init<const std::optional<TokenizerWrapper>&, bool, py::kwargs>(),
          py::arg("tokenizer")=py::none(),
          py::arg("keep_vocab")=false)
     ;

--- a/bindings/python/pyonmttok/Python.cc
+++ b/bindings/python/pyonmttok/Python.cc
@@ -154,21 +154,11 @@ public:
            const bool as_token_objects,
            const bool training) const
   {
+    std::vector<onmt::Token> tokens;
+    _tokenizer->tokenize(text, tokens, training);
     if (as_token_objects)
-    {
-      std::vector<onmt::Token> tokens;
-      _tokenizer->tokenize(text, tokens, training);
       return tokens;
-    }
-
-    std::vector<std::string> words;
-    std::vector<std::vector<std::string>> features;
-    _tokenizer->tokenize(text, words, features, training);
-
-    std::optional<std::vector<std::vector<std::string>>> optional_features;
-    if (!features.empty())
-      optional_features = std::move(features);
-    return std::make_pair(std::move(words), std::move(optional_features));
+    return serialize_tokens(tokens);
   }
 
   std::pair<std::vector<std::string>, std::optional<std::vector<std::vector<std::string>>>>

--- a/bindings/python/pyonmttok/Python.cc
+++ b/bindings/python/pyonmttok/Python.cc
@@ -618,13 +618,6 @@ PYBIND11_MODULE(_ext, m)
          py::arg("training")=true,
          py::call_guard<py::gil_scoped_release>())
 
-    .def("serialize_tokens", &TokenizerWrapper::serialize_tokens,
-         py::arg("tokens"))
-    .def("deserialize_tokens", &TokenizerWrapper::deserialize_tokens,
-         py::arg("tokens"),
-         py::arg("features")=py::none(),
-         py::call_guard<py::gil_scoped_release>())
-
     .def("detokenize",
          py::overload_cast<
          const std::vector<std::string>&,
@@ -660,6 +653,13 @@ PYBIND11_MODULE(_ext, m)
     .def("detokenize_file", &TokenizerWrapper::detokenize_file,
          py::arg("input_path"),
          py::arg("output_path"),
+         py::call_guard<py::gil_scoped_release>())
+
+    .def("serialize_tokens", &TokenizerWrapper::serialize_tokens,
+         py::arg("tokens"))
+    .def("deserialize_tokens", &TokenizerWrapper::deserialize_tokens,
+         py::arg("tokens"),
+         py::arg("features")=py::none(),
          py::call_guard<py::gil_scoped_release>())
 
     .def("__copy__", [](const TokenizerWrapper& wrapper) {

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -28,7 +28,7 @@ def _maybe_add_library_root(lib_name, header_only=False):
 
 _maybe_add_library_root("TOKENIZER")
 
-cflags = ["-std=c++11", "-fvisibility=hidden"]
+cflags = ["-std=c++17", "-fvisibility=hidden"]
 ldflags = []
 if sys.platform == "darwin":
     cflags.append("-mmacosx-version-min=10.9")

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -31,7 +31,7 @@ _maybe_add_library_root("TOKENIZER")
 cflags = ["-std=c++17", "-fvisibility=hidden"]
 ldflags = []
 if sys.platform == "darwin":
-    cflags.append("-mmacosx-version-min=10.9")
+    cflags.append("-mmacosx-version-min=10.14")
     ldflags.append("-Wl,-rpath,/usr/local/lib")
 
 tokenizer_module = Extension(

--- a/bindings/python/test/test.py
+++ b/bindings/python/test/test.py
@@ -26,6 +26,11 @@ def test_simple():
     detok = tokenizer.detokenize(tokens)
     assert detok == text
 
+def test_empty():
+    tokenizer = pyonmttok.Tokenizer("conservative")
+    assert tokenizer.tokenize("") == ([], None)
+    assert tokenizer.detokenize([]) == ""
+
 def test_options():
     options = {
         "mode": "aggressive",

--- a/bindings/python/tools/prepare_build_environment.sh
+++ b/bindings/python/tools/prepare_build_environment.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 
 ROOT_DIR=$PWD
-ICU_VERSION=${ICU_VERSION:-66.1}
+ICU_VERSION=${ICU_VERSION:-69.1}
 
 # Install ICU.
 curl -L -O https://github.com/unicode-org/icu/releases/download/release-${ICU_VERSION/./-}/icu4c-${ICU_VERSION/./_}-src.tgz


### PR DESCRIPTION
* Update manylinux to 2010
* Update pybind11 to 2.7.1
* Update ICU to 69.1

With manylinux2010 we can compile with C++17. This enables new features in pybind11 that makes the function signature clearer and improves the type checking. Here's an example from `help(pyonmttok.Tokenizer)`:

Before:

```text
 |  detokenize(...)
 |      detokenize(self: pyonmttok._ext.Tokenizer, tokens: list, features: object = None) -> str

```

After:

```text
 |  detokenize(...)
 |      detokenize(*args, **kwargs)
 |      Overloaded function.
 |      
 |      1. detokenize(self: pyonmttok._ext.Tokenizer, tokens: List[str], features: Optional[List[List[str]]] = None) -> str
 |      
 |      2. detokenize(self: pyonmttok._ext.Tokenizer, tokens: List[pyonmttok._ext.Token]) -> str
```