### PR TITLE
Add aarch64 wheel build support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,17 +76,25 @@ jobs:
 
 
   build-and-test-python-wheels:
-    name: Build and test Python wheels on ${{ matrix.os }}
+    name: Build and test wheels on ${{ matrix.os }} for ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-10.15, windows-2019]
+        arch: [auto64]
+        include:
+        - os: ubuntu-20.04
+          arch: aarch64
 
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+
+      - uses: docker/setup-qemu-action@v1
+        if: ${{ matrix.arch == 'aarch64' }}
+        name: Set up QEMU
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.1.3
@@ -101,7 +109,7 @@ jobs:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
           CIBW_TEST_COMMAND: pytest {project}/bindings/python/test/test.py
           CIBW_TEST_REQUIRES: pytest
-          CIBW_ARCHS: auto64
+          CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_SKIP: pp*
 
       - name: Upload Python wheels


### PR DESCRIPTION
Added linux aarch64 wheel support.

Related to: https://github.com/OpenNMT/Tokenizer/issues/273