### PR TITLE
Improve lang validity check

### DIFF
--- a/bindings/python/test/test.py
+++ b/bindings/python/test/test.py
@@ -56,6 +56,10 @@ def test_invalid_lang():
         pyonmttok.Tokenizer("conservative", lang="xxx")
 
 
+def test_deprecated_lang():
+    pyonmttok.Tokenizer("conservative", lang="tl")
+
+
 def test_invalid_sentencepiece_model():
     with pytest.raises(ValueError):
         pyonmttok.Tokenizer("none", sp_model_path="xxx")

--- a/src/unicode/Unicode.cc
+++ b/src/unicode/Unicode.cc
@@ -235,14 +235,9 @@ namespace onmt
 
     bool is_valid_language(const char* language)
     {
-      for (const char* const* available_languages = icu::Locale::getISOLanguages();
-           *available_languages;
-           ++available_languages)
-      {
-        if (strcmp(*available_languages, language) == 0)
-          return true;
-      }
-      return false;
+      const icu::Locale locale(language);
+      const char* iso3_lang = locale.getISO3Language();
+      return iso3_lang[0] != '\0';
     }
 
     // The functions below are made backward compatible with the Kangxi and Kanbun script names

--- a/src/unicode/Unicode.cc
+++ b/src/unicode/Unicode.cc
@@ -235,9 +235,7 @@ namespace onmt
 
     bool is_valid_language(const char* language)
     {
-      const icu::Locale locale(language);
-      const char* iso3_lang = locale.getISO3Language();
-      return iso3_lang[0] != '\0';
+      return icu::Locale(language).getISO3Language()[0] != '\0';
     }
 
     // The functions below are made backward compatible with the Kangxi and Kanbun script names


### PR DESCRIPTION
The list returned by `getISOLanguages` does not include deprecated language codes that are still accepted to create locales.