### PR TITLE
Add basic Tokenizer.__call__ method

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pip install pyonmttok
 ```python
 >>> import pyonmttok
 >>> tokenizer = pyonmttok.Tokenizer("conservative", joiner_annotate=True)
->>> tokens, _ = tokenizer.tokenize("Hello World!")
+>>> tokens = tokenizer("Hello World!")
 >>> tokens
 ['Hello', 'World', '￭!']
 >>> tokenizer.detokenize(tokens)

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -28,7 +28,7 @@ pip install pyonmttok
 ```python
 >>> import pyonmtok
 >>> tokenizer = pyonmttok.Tokenizer("aggressive", joiner_annotate=True)
->>> tokens, _ = tokenizer.tokenize("Hello World!")
+>>> tokens = tokenizer("Hello World!")
 >>> tokens
 ['Hello', 'World', '￭!']
 >>> tokenizer.detokenize(tokens)
@@ -91,16 +91,19 @@ See the [documentation](https://github.com/OpenNMT/Tokenizer/blob/master/docs/op
 #### Tokenization
 
 ```python
-# By default, tokenize returns the tokens and features.
-# When as_token_objects=True, the method returns Token objects (see below).
+# Tokenize a text.
 # When training=False, subword regularization such as BPE dropout is disabled.
+tokenizer.__call__(text: str, training: bool = True) -> List[str]
+
+# Tokenize a text and return optional features.
+# When as_token_objects=True, the method returns Token objects (see below).
 tokenizer.tokenize(
     text: str,
     as_token_objects: bool = False,
     training: bool = True,
 ) -> Union[Tuple[List[str], Optional[List[List[str]]]], List[pyonmttok.Token]]
 
-# Batch version of tokenize method.
+# Tokenize a batch of text.
 tokenizer.tokenize_batch(
     batch_text: List[str],
     as_token_objects: bool = False,

--- a/bindings/python/pyonmttok/Python.cc
+++ b/bindings/python/pyonmttok/Python.cc
@@ -123,6 +123,13 @@ public:
       );
   }
 
+  std::vector<std::string> call(const std::string& text, const bool training) const
+  {
+    std::vector<std::string> tokens;
+    _tokenizer->tokenize(text, tokens, training);
+    return tokens;
+  }
+
   std::variant<
     std::pair<std::vector<std::string>, std::optional<std::vector<std::vector<std::string>>>>,
     std::vector<onmt::Token>>
@@ -608,6 +615,10 @@ PYBIND11_MODULE(_ext, m)
 
     .def_property_readonly("options", &TokenizerWrapper::get_options)
 
+    .def("__call__", &TokenizerWrapper::call,
+         py::arg("text"),
+         py::arg("training")=true,
+         py::call_guard<py::gil_scoped_release>())
     .def("tokenize", &TokenizerWrapper::tokenize,
          py::arg("text"),
          py::arg("as_token_objects")=false,

--- a/bindings/python/test/test.py
+++ b/bindings/python/test/test.py
@@ -26,6 +26,11 @@ def test_simple():
     assert detok == text
 
 
+def test_call():
+    tokenizer = pyonmttok.Tokenizer("aggressive", joiner_annotate=True, joiner_new=True)
+    assert tokenizer("Hello World!") == ["Hello", "World", "￭", "!"]
+
+
 def test_empty():
     tokenizer = pyonmttok.Tokenizer("conservative")
     assert tokenizer.tokenize("") == ([], None)


### PR DESCRIPTION
This simplifies the usage of the tokenizer when no features are returned (the common case).