### PR TITLE
Fix BPELearner segfault when there is not a single pair of characters

### DIFF
--- a/bindings/python/test/test.py
+++ b/bindings/python/test/test.py
@@ -332,6 +332,15 @@ def test_bpe_learner_tokens(tmpdir):
         assert model.read() == "#version: 0.2\na b</w>\nc d</w>\n"
 
 
+def test_bpe_learner_no_pairs(tmpdir):
+    tokenizer = pyonmttok.Tokenizer("aggressive", joiner_annotate=True)
+    learner = pyonmttok.BPELearner(tokenizer=tokenizer, symbols=2, min_frequency=1)
+    learner.ingest("a b")
+    model_path = str(tmpdir.join("bpe.model"))
+    with pytest.raises(RuntimeError, match="pairs"):
+        tokenizer = learner.learn(model_path)
+
+
 @pytest.mark.parametrize("keep_vocab", [False, True])
 def test_sp_learner(tmpdir, keep_vocab):
     learner = pyonmttok.SentencePieceLearner(

--- a/src/BPELearner.cc
+++ b/src/BPELearner.cc
@@ -308,6 +308,9 @@ namespace onmt
     std::unordered_map<const bigram*, std::unordered_map<int, int>> indices;
     get_pair_statistics(collection, sorted_vocab, stats, indices);
 
+    if (stats.empty())
+      throw std::runtime_error("No pairs of characters were found in the ingested data");
+
     std::unordered_map<const bigram*, int> big_stats(stats);
 
     if (_total_symbols) {


### PR DESCRIPTION
This case does not happen with real data, but we should avoid hard crashes.