### PR TITLE
Minor fixes addressing issue #330

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ project(OpenNMTTokenizer)
 option(BUILD_TESTS "Compile unit tests" OFF)
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 if(CMAKE_VERSION VERSION_LESS "3.7.0")
   set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 endif()

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ See the `-h` flag to list the available options.
 git submodule update --init
 mkdir build
 cd build
-cmake ..
+cmake .. -DICU_ROOT=<path to root of ICU dependencies>
 make
 ```
 


### PR DESCRIPTION
Updated CMAKE_CXX_STANDARD to 17 and updated the documentation to include the -DICU_ROOT definition when calling CMake to generate the project.