### PR TITLE
Fix compile with latest ICU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,16 @@ if(POLICY CMP0091)
   cmake_policy(SET CMP0091 NEW)
 endif()
 
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
 project(OpenNMTTokenizer)
 
 option(BUILD_TESTS "Compile unit tests" OFF)
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 if(CMAKE_VERSION VERSION_LESS "3.7.0")
   set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 endif()


### PR DESCRIPTION
- Require C++17 for newer ICU versions
- Add CMake policy CMP0074 to suppress warning